### PR TITLE
feat: Add 10 common Spanish verbs with example sentences

### DIFF
--- a/lang_data/dar/condicional.txt
+++ b/lang_data/dar/condicional.txt
@@ -1,0 +1,6 @@
+Si tuviera más dinero, yo ______ (dar) una gran fiesta.;daría
+¿Tú le ______ (dar) una segunda oportunidad si te la pidiera?;darías
+Él ______ (dar) cualquier cosa por volver a verla.;daría
+Nosotros ______ (dar) un donativo si la causa fuera justa.;daríamos
+Vosotros ______ (dar) mejores regalos si tuvierais más imaginación.;daríais
+Ellos ______ (dar) la vuelta al mundo si pudieran.;darían

--- a/lang_data/dar/futuro.txt
+++ b/lang_data/dar/futuro.txt
@@ -1,0 +1,6 @@
+Mañana yo te ______ (dar) mi respuesta definitiva.;daré
+¿Cuándo me ______ (dar) tú el dinero que me debes?;darás
+Él le ______ (dar) una sorpresa a su novia por su aniversario.;dará
+Nosotros ______ (dar) un concierto en el auditorio municipal.;daremos
+Vosotros ______ (dar) vuestra opinión en la próxima reunión.;daréis
+Ellos ______ (dar) una conferencia sobre el cambio climático.;darán

--- a/lang_data/dar/imperativo_afirmativo.txt
+++ b/lang_data/dar/imperativo_afirmativo.txt
@@ -1,0 +1,5 @@
+(Tú) ¡______ (dar) las gracias cuando recibas algo!;da
+(Usted) ______ (dar) un discurso inspirador en la conferencia.;dé
+(Nosotros) ______ (dar) la bienvenida a los nuevos miembros.;demos
+(Vosotros) ¡______ (dar) lo mejor de vosotros en el partido!;dad
+(Ustedes) ______ (dar) sus opiniones durante la reunión.;den

--- a/lang_data/dar/imperfecto.txt
+++ b/lang_data/dar/imperfecto.txt
@@ -1,0 +1,6 @@
+Cuando era niño, yo siempre ______ (dar) problemas a mis padres.;daba
+Tú ______ (dar) largos paseos por la playa en verano.;dabas
+Él ______ (dar) de comer a su perro todas las mañanas.;daba
+Nosotros ______ (dar) una vuelta por el pueblo los domingos.;dábamos
+Vosotros ______ (dar) regalos a vuestros amigos en Navidad.;dabais
+Ellos ______ (dar) clases de baile en la escuela del barrio.;daban

--- a/lang_data/dar/pluscuamperfecto.txt
+++ b/lang_data/dar/pluscuamperfecto.txt
@@ -1,0 +1,6 @@
+Yo ya le ______ (dar) el regalo antes de que llegara.;había dado
+Tú ______ (dar) tu palabra, no podías retractarte.;habías dado
+Él nos ______ (dar) su apoyo incondicional desde el principio.;había dado
+Nosotros ______ (dar) por sentado que vendrían a la fiesta.;habíamos dado
+Vosotros ______ (dar) la señal de alarma antes de que fuera tarde.;habíais dado
+Ellos ______ (dar) una respuesta afirmativa la semana anterior.;habían dado

--- a/lang_data/dar/presente.txt
+++ b/lang_data/dar/presente.txt
@@ -1,0 +1,6 @@
+Yo siempre ______ (dar) regalos en los cumpleaños.;doy
+Tú ______ (dar) muy buenos consejos.;das
+Él ______ (dar) clases de matemáticas en la universidad.;da
+Nosotros ______ (dar) un paseo por el parque cada tarde.;damos
+Vosotros ______ (dar) de comer a los patos en el estanque.;dais
+Ellos ______ (dar) una fiesta este fin de semana.;dan

--- a/lang_data/dar/preterito_indefinido.txt
+++ b/lang_data/dar/preterito_indefinido.txt
@@ -1,0 +1,6 @@
+Ayer yo le ______ (dar) una sorpresa a mi hermano.;di
+¿Qué le ______ (dar) tú a tu madre por su cumpleaños?;diste
+Él ______ (dar) un discurso muy emotivo en la ceremonia.;dio
+Nosotros ______ (dar) un paseo por la ciudad anoche.;dimos
+Vosotros le ______ (dar) una oportunidad, pero no la aprovechó.;disteis
+Ellos ______ (dar) las gracias por la ayuda recibida.;dieron

--- a/lang_data/dar/preterito_perfecto_compuesto.txt
+++ b/lang_data/dar/preterito_perfecto_compuesto.txt
@@ -1,0 +1,6 @@
+Yo le ______ (dar) el libro esta mañana.;he dado
+¿Tú le ______ (dar) la noticia a María?;has dado
+Él siempre nos ______ (dar) buenos ejemplos.;ha dado
+Nosotros ______ (dar) nuestro mejor esfuerzo en el proyecto.;hemos dado
+Vosotros ______ (dar) un gran espectáculo en la función.;habéis dado
+Ellos ______ (dar) muchas oportunidades a los empleados nuevos.;han dado

--- a/lang_data/dar/subjuntivo_imperfecto_ra.txt
+++ b/lang_data/dar/subjuntivo_imperfecto_ra.txt
@@ -1,0 +1,6 @@
+Si yo te ______ (dar) mi opinión, ¿te enfadarías?;diera
+Si tú me ______ (dar) más tiempo, lo terminaría.;dieras
+Si él nos ______ (dar) permiso, iríamos a la fiesta.;diera
+Si nosotros le ______ (dar) una oportunidad, podría sorprendernos.;diéramos
+Si vosotros ______ (dar) un paso al frente, cambiaríais la situación.;dierais
+Si ellos ______ (dar) su brazo a torcer, el acuerdo sería posible.;dieran

--- a/lang_data/dar/subjuntivo_presente.txt
+++ b/lang_data/dar/subjuntivo_presente.txt
@@ -1,0 +1,6 @@
+Espero que yo le ______ (dar) una buena impresión al entrevistador.;dé
+Es importante que tú ______ (dar) las gracias por el regalo.;des
+Es posible que él nos ______ (dar) una explicación convincente.;dé
+Es necesario que nosotros ______ (dar) nuestro consentimiento para el procedimiento.;demos
+Dudo que vosotros le ______ (dar) tanta importancia a ese asunto.;deis
+Es probable que ellos nos ______ (dar) una cálida bienvenida.;den

--- a/lang_data/decir/condicional.txt
+++ b/lang_data/decir/condicional.txt
@@ -1,0 +1,6 @@
+Si supiera la respuesta, yo te la ______ (decir).;diría
+¿Qué ______ (decir) tú en mi lugar?;dirías
+Él ______ (decir) cualquier cosa para salvarse.;diría
+Nosotros ______ (decir) que sí, si nos invitaran.;diríamos
+Vosotros ______ (decir) la verdad, ¿no es cierto?;diríais
+Ellos ______ (decir) que están ocupados para no venir.;dirían

--- a/lang_data/decir/futuro.txt
+++ b/lang_data/decir/futuro.txt
@@ -1,0 +1,6 @@
+Mañana yo te ______ (decir) lo que decida.;diré
+¿Qué ______ (decir) tú cuando lo veas?;dirás
+Él ______ (decir) la verdad tarde o temprano.;dirá
+Nosotros ______ (decir) nuestro discurso en la conferencia.;diremos
+Vosotros ______ (decir) lo que habéis aprendido en el curso.;diréis
+Ellos ______ (decir) si están de acuerdo con el plan.;dirán

--- a/lang_data/decir/imperativo_afirmativo.txt
+++ b/lang_data/decir/imperativo_afirmativo.txt
@@ -1,0 +1,5 @@
+(Tú) ¡______ (decir) la verdad ahora mismo!;di
+(Usted) ______ (decir) su nombre completo, por favor.;diga
+(Nosotros) ______ (decir) qué pensamos sobre este asunto.;digamos
+(Vosotros) ¡______ (decir) lo que sabéis sin miedo!;decid
+(Ustedes) ______ (decir) si están de acuerdo o no.;digan

--- a/lang_data/decir/imperfecto.txt
+++ b/lang_data/decir/imperfecto.txt
@@ -1,0 +1,6 @@
+Cuando era pequeño, yo siempre ______ (decir) la verdad a mis padres.;decía
+Tú ______ (decir) que querías ser astronauta.;decías
+Él ______ (decir) chistes muy buenos en las fiestas.;decía
+Nosotros ______ (decir) que íbamos a ganar el campeonato.;decíamos
+Vosotros siempre ______ (decir) que estudiaríais más.;decíais
+Ellos ______ (decir) que el viaje era demasiado largo.;decían

--- a/lang_data/decir/pluscuamperfecto.txt
+++ b/lang_data/decir/pluscuamperfecto.txt
@@ -1,0 +1,6 @@
+Yo ya te ______ (decir) que no quería ir antes de que insistieras.;había dicho
+Tú me ______ (decir) que habías terminado el proyecto, pero no era verdad.;habías dicho
+Él ______ (decir) que llegaría temprano, pero se retrasó.;había dicho
+Nosotros ______ (decir) que no estábamos de acuerdo con la propuesta inicial.;habíamos dicho
+Vosotros ______ (decir) que lo haríais, pero no cumplisteis.;habíais dicho
+Ellos ______ (decir) que el examen había sido fácil, pero suspendieron.;habían dicho

--- a/lang_data/decir/presente.txt
+++ b/lang_data/decir/presente.txt
@@ -1,0 +1,6 @@
+Yo siempre ______ (decir) la verdad.;digo
+Tú ______ (decir) cosas muy interesantes.;dices
+Él ______ (decir) que vendrá mañana.;dice
+Nosotros ______ (decir) lo que pensamos.;decimos
+Vosotros ______ (decir) que es fácil, pero no lo es.;decís
+Ellos ______ (decir) que están de acuerdo.;dicen

--- a/lang_data/decir/preterito_indefinido.txt
+++ b/lang_data/decir/preterito_indefinido.txt
@@ -1,0 +1,6 @@
+Ayer yo te ______ (decir) que no vinieras.;dije
+¿Qué ______ (decir) tú cuando te enteraste de la noticia?;dijiste
+Él ______ (decir) que no sabía nada al respecto.;dijo
+Nosotros ______ (decir) la verdad durante el interrogatorio.;dijimos
+Vosotros ______ (decir) que estabais cansados, por eso no fuisteis.;dijisteis
+Ellos ______ (decir) que llegarían tarde a la cena.;dijeron

--- a/lang_data/decir/preterito_perfecto_compuesto.txt
+++ b/lang_data/decir/preterito_perfecto_compuesto.txt
@@ -1,0 +1,6 @@
+Hoy yo ______ (decir) toda la verdad en la reunión.;he dicho
+Esta semana tú ______ (decir) muchas cosas importantes.;has dicho
+Él siempre ______ (decir) lo que piensa sin filtros.;ha dicho
+Nosotros ______ (decir) que apoyaríamos la causa.;hemos dicho
+Vosotros ______ (decir) que vendríais, ¿qué pasó?;habéis dicho
+Ellos ______ (decir) que no están interesados en la oferta.;han dicho

--- a/lang_data/decir/subjuntivo_imperfecto_ra.txt
+++ b/lang_data/decir/subjuntivo_imperfecto_ra.txt
@@ -1,0 +1,6 @@
+Si yo ______ (decir) lo que pienso, se enfadarían.;dijera
+Si tú ______ (decir) la verdad, te creerían.;dijeras
+Si él ______ (decir) que viene, lo esperaríamos.;dijera
+Si nosotros ______ (decir) que no, ¿qué pasaría?;dijéramos
+Si vosotros ______ (decir) que estáis ocupados, lo entenderían.;dijerais
+Si ellos ______ (decir) que necesitan ayuda, los apoyaríamos.;dijeran

--- a/lang_data/decir/subjuntivo_presente.txt
+++ b/lang_data/decir/subjuntivo_presente.txt
@@ -1,0 +1,6 @@
+Espero que yo no ______ (decir) ninguna tontería.;diga
+Es importante que tú ______ (decir) lo que sientes.;digas
+Es posible que él ______ (decir) que no puede venir.;diga
+Es necesario que nosotros ______ (decir) la verdad sobre lo ocurrido.;digamos
+Dudo que vosotros ______ (decir) siempre lo que pensáis.;digáis
+Es probable que ellos ______ (decir) que necesitan más tiempo.;digan

--- a/lang_data/estar/condicional.txt
+++ b/lang_data/estar/condicional.txt
@@ -1,0 +1,6 @@
+Si tuviera tiempo, yo ______ (estar) en el parque ahora mismo.;estaría
+Tú ______ (estar) más relajado si durmieras más.;estarías
+Él ______ (estar) muy agradecido si lo ayudaras.;estaría
+Nosotros ______ (estar) encantados de acompañarte, si pudiéramos.;estaríamos
+Vosotros ______ (estar) mejor si os abrigarais.;estaríais
+Ellos ______ (estar) más contentos si ganaran el partido.;estarían

--- a/lang_data/estar/futuro.txt
+++ b/lang_data/estar/futuro.txt
@@ -1,0 +1,6 @@
+Mañana yo ______ (estar) en casa todo el día.;estaré
+La próxima semana tú ______ (estar) de viaje.;estarás
+Él ______ (estar) disponible para la reunión de mañana.;estará
+Nosotros ______ (estar) más tranquilos cuando termine el examen.;estaremos
+Vosotros ______ (estar) muy ocupados con los preparativos.;estaréis
+Ellos ______ (estar) esperándonos en la entrada.;estarán

--- a/lang_data/estar/imperativo_afirmativo.txt
+++ b/lang_data/estar/imperativo_afirmativo.txt
@@ -1,0 +1,5 @@
+(Tú) ¡______ (estar) quieto un momento!;está
+(Usted) ______ (estar) preparado para la presentación.;esté
+(Nosotros) ______ (estar) atentos a las instrucciones.;estemos
+(Vosotros) ¡______ (estar) listos para salir en cinco minutos!;estad
+(Ustedes) ______ (estar) tranquilos, todo está bajo control.;estén

--- a/lang_data/estar/imperfecto.txt
+++ b/lang_data/estar/imperfecto.txt
@@ -1,0 +1,6 @@
+Cuando era joven, yo ______ (estar) siempre jugando afuera.;estaba
+Antes, tú ______ (estar) más tiempo en casa.;estabas
+Él ______ (estar) muy enfermo la semana pasada.;estaba
+Nosotros ______ (estar) de vacaciones cuando llamaste.;estábamos
+Vosotros ______ (estar) en el parque todos los días.;estabais
+Ellos ______ (estar) muy contentos en la fiesta de anoche.;estaban

--- a/lang_data/estar/pluscuamperfecto.txt
+++ b/lang_data/estar/pluscuamperfecto.txt
@@ -1,0 +1,6 @@
+Cuando llegué, yo ya ______ (estar) listo por horas.;había estado
+Antes de la llamada, tú ______ (estar) durmiendo.;habías estado
+Él ______ (estar) en esa posición antes de la promoción.;había estado
+Nosotros ______ (estar) allí muchas veces antes de la última visita.;habíamos estado
+Vosotros ya ______ (estar) en el cine cuando os escribí.;habíais estado
+Ellos ______ (estar) preocupados hasta que recibieron la noticia.;habían estado

--- a/lang_data/estar/presente.txt
+++ b/lang_data/estar/presente.txt
@@ -1,0 +1,6 @@
+Yo ______ (estar) en la biblioteca.;estoy
+Tú ______ (estar) muy cansado hoy.;estás
+Ella ______ (estar) contenta con su nuevo trabajo.;está
+Nosotros ______ (estar) esperando el autobús.;estamos
+Vosotros ______ (estar) de vacaciones en la playa.;estáis
+Ustedes ______ (estar) en el lugar correcto.;están

--- a/lang_data/estar/preterito_indefinido.txt
+++ b/lang_data/estar/preterito_indefinido.txt
@@ -1,0 +1,6 @@
+Ayer yo ______ (estar) en el supermercado.;estuve
+La semana pasada tú ______ (estar) de viaje de negocios.;estuviste
+Él ______ (estar) ausente en la reunión de ayer.;estuvo
+Nosotros ______ (estar) juntos en el concierto.;estuvimos
+Vosotros ______ (estar) en la fiesta hasta tarde.;estuvisteis
+Ellos ______ (estar) muy callados durante la cena.;estuvieron

--- a/lang_data/estar/preterito_perfecto_compuesto.txt
+++ b/lang_data/estar/preterito_perfecto_compuesto.txt
@@ -1,0 +1,6 @@
+Esta mañana yo ______ (estar) en el médico.;he estado
+Hoy tú ______ (estar) muy ocupado en la oficina.;has estado
+Ella ______ (estar) de viaje toda la semana.;ha estado
+Nosotros ______ (estar) trabajando en este proyecto por meses.;hemos estado
+Vosotros ______ (estar) esperando noticias desde ayer.;habéis estado
+Ellos ______ (estar) en silencio durante toda la reunión.;han estado

--- a/lang_data/estar/subjuntivo_imperfecto_ra.txt
+++ b/lang_data/estar/subjuntivo_imperfecto_ra.txt
@@ -1,0 +1,6 @@
+Si yo ______ (estar) más cerca, te visitaría.;estuviera
+Si tú ______ (estar) aquí, todo sería diferente.;estuvieras
+Si él ______ (estar) en casa, podríamos hablar.;estuviera
+Si nosotros ______ (estar) de acuerdo, empezaríamos el proyecto.;estuviéramos
+Si vosotros ______ (estar) menos ocupados, vendríais a la fiesta.;estuvierais
+Si ellos ______ (estar) más atentos, entenderían el problema.;estuvieran

--- a/lang_data/estar/subjuntivo_presente.txt
+++ b/lang_data/estar/subjuntivo_presente.txt
@@ -1,0 +1,6 @@
+Espero que yo ______ (estar) a tiempo para la reunión.;esté
+Es necesario que tú ______ (estar) tranquilo.;estés
+Es posible que ella ______ (estar) en la oficina.;esté
+Es importante que nosotros ______ (estar) preparados.;estemos
+Dudo que vosotros ______ (estar) listos para el examen.;estéis
+Es probable que ellos ______ (estar) de acuerdo con la propuesta.;estén

--- a/lang_data/hacer/condicional.txt
+++ b/lang_data/hacer/condicional.txt
@@ -1,0 +1,6 @@
+Si tuviera los ingredientes, yo ______ (hacer) un pastel.;haría
+Tú ______ (hacer) lo mismo en mi situación, ¿verdad?;harías
+Él ______ (hacer) cualquier cosa por sus amigos.;haría
+Nosotros ______ (hacer) la tarea juntos si estuviéramos en la misma clase.;haríamos
+Vosotros ______ (hacer) bien en revisar el documento antes de enviarlo.;haríais
+Ellas ______ (hacer) un viaje alrededor del mundo si tuvieran dinero.;harían

--- a/lang_data/hacer/futuro.txt
+++ b/lang_data/hacer/futuro.txt
@@ -1,0 +1,6 @@
+Mañana yo ______ (hacer) la compra semanal.;haré
+El próximo mes tú ______ (hacer) un curso de fotografía.;harás
+Él ______ (hacer) todo lo posible para ayudarte.;hará
+Nosotros ______ (hacer) una fiesta si ganamos el partido.;haremos
+Vosotros ______ (hacer) el examen final la próxima semana.;haréis
+Ellas ______ (hacer) una presentación sobre el cambio climático.;harán

--- a/lang_data/hacer/imperativo_afirmativo.txt
+++ b/lang_data/hacer/imperativo_afirmativo.txt
@@ -1,0 +1,5 @@
+(Tú) ¡______ (hacer) tu cama ahora mismo!;haz
+(Usted) ______ (hacer) el favor de esperar un momento.;haga
+(Nosotros) ______ (hacer) un brindis por los novios.;hagamos
+(Vosotros) ¡______ (hacer) los deberes antes de salir a jugar!;haced
+(Ustedes) ______ (hacer) silencio en la biblioteca.;hagan

--- a/lang_data/hacer/imperfecto.txt
+++ b/lang_data/hacer/imperfecto.txt
@@ -1,0 +1,6 @@
+De niño, yo siempre ______ (hacer) mis deberes después de merendar.;hacía
+Tú ______ (hacer) mucho deporte cuando vivías en la costa.;hacías
+Él ______ (hacer) maquetas de aviones en su tiempo libre.;hacía
+Nosotros ______ (hacer) senderismo los fines de semana.;hacíamos
+Vosotros ______ (hacer) tartas deliciosas para los cumpleaños.;hacíais
+Ellas ______ (hacer) yoga en el parque cada mañana.;hacían

--- a/lang_data/hacer/pluscuamperfecto.txt
+++ b/lang_data/hacer/pluscuamperfecto.txt
@@ -1,0 +1,6 @@
+Yo ya ______ (hacer) la compra cuando me llamaste.;había hecho
+Tú ______ (hacer) el ridículo antes de darte cuenta.;habías hecho
+Él ______ (hacer) un gran descubrimiento antes de publicarlo.;había hecho
+Nosotros ______ (hacer) todo lo posible antes de rendirnos.;habíamos hecho
+Vosotros ______ (hacer) la reserva antes de llegar al hotel.;habíais hecho
+Ellas ______ (hacer) el trabajo antes de la fecha límite.;habían hecho

--- a/lang_data/hacer/presente.txt
+++ b/lang_data/hacer/presente.txt
@@ -1,0 +1,6 @@
+Yo ______ (hacer) mi tarea por la tarde.;hago
+Tú ______ (hacer) mucho ruido cuando cocinas.;haces
+Él ______ (hacer) ejercicio todas las mañanas.;hace
+Nosotros ______ (hacer) planes para el fin de semana.;hacemos
+Vosotros ______ (hacer) un gran trabajo en equipo.;hacéis
+Ellas ______ (hacer) pasteles deliciosos.;hacen

--- a/lang_data/hacer/preterito_indefinido.txt
+++ b/lang_data/hacer/preterito_indefinido.txt
@@ -1,0 +1,6 @@
+Ayer yo ______ (hacer) la cena para mi familia.;hice
+La semana pasada tú ______ (hacer) un viaje a la montaña.;hiciste
+Él ______ (hacer) un pastel de chocolate el sábado.;hizo
+Nosotros ______ (hacer) una fogata en la playa anoche.;hicimos
+Vosotros ______ (hacer) un buen trabajo con la presentación.;hicisteis
+Ellas ______ (hacer) sus maletas justo antes de salir.;hicieron

--- a/lang_data/hacer/preterito_perfecto_compuesto.txt
+++ b/lang_data/hacer/preterito_perfecto_compuesto.txt
@@ -1,0 +1,6 @@
+Hoy yo ______ (hacer) todo lo que estaba en mi lista.;he hecho
+Esta semana tú ______ (hacer) un gran esfuerzo.;has hecho
+Él ______ (hacer) la cena para nosotros esta noche.;ha hecho
+Nosotros ______ (hacer) progresos significativos en el proyecto.;hemos hecho
+Vosotros ______ (hacer) muchas preguntas interesantes hoy.;habéis hecho
+Ellas ______ (hacer) un descubrimiento importante.;han hecho

--- a/lang_data/hacer/subjuntivo_imperfecto_ra.txt
+++ b/lang_data/hacer/subjuntivo_imperfecto_ra.txt
@@ -1,0 +1,6 @@
+Si yo ______ (hacer) más ejercicio, estaría en forma.;hiciera
+Si tú ______ (hacer) tu cama cada mañana, tu cuarto se vería mejor.;hicieras
+Si él ______ (hacer) menos ruido, los vecinos no se quejarían.;hiciera
+Si nosotros ______ (hacer) un esfuerzo, podríamos terminar a tiempo.;hiciéramos
+Si vosotros ______ (hacer) caso a las instrucciones, no tendríais problemas.;hicierais
+Si ellas ______ (hacer) la tarea, obtendrían mejores notas.;hicieran

--- a/lang_data/hacer/subjuntivo_presente.txt
+++ b/lang_data/hacer/subjuntivo_presente.txt
@@ -1,0 +1,6 @@
+Espero que yo ______ (hacer) un buen trabajo.;haga
+Es importante que tú ______ (hacer) ejercicio regularmente.;hagas
+Es posible que ella ______ (hacer) la tarta para la fiesta.;haga
+Es necesario que nosotros ______ (hacer) algo para ayudar.;hagamos
+Dudo que vosotros ______ (hacer) todo el trabajo a tiempo.;hagáis
+Es probable que ellas ______ (hacer) lo correcto.;hagan

--- a/lang_data/ir/condicional.txt
+++ b/lang_data/ir/condicional.txt
@@ -1,0 +1,6 @@
+Si tuviera tiempo, yo ______ (ir) al cine más a menudo.;iría
+¿Tú ______ (ir) a la fiesta si te invitaran?;irías
+Él ______ (ir) con nosotros si no tuviera que trabajar.;iría
+Nosotros ______ (ir) a la playa si hiciera mejor tiempo.;iríamos
+Vosotros ______ (ir) de viaje si ganarais la lotería.;iríais
+Ellos ______ (ir) al concierto si tuvieran entradas.;irían

--- a/lang_data/ir/futuro.txt
+++ b/lang_data/ir/futuro.txt
@@ -1,0 +1,6 @@
+Mañana yo ______ (ir) a la playa si hace buen tiempo.;iré
+¿Cuándo ______ (ir) tú a visitar a tus abuelos?;irás
+Él ______ (ir) al médico la próxima semana.;irá
+Nosotros ______ (ir) de compras este fin de semana.;iremos
+Vosotros ______ (ir) a la fiesta de cumpleaños de María, ¿verdad?;iréis
+Ellos ______ (ir) de viaje a Europa el próximo mes.;irán

--- a/lang_data/ir/imperativo_afirmativo.txt
+++ b/lang_data/ir/imperativo_afirmativo.txt
@@ -1,0 +1,5 @@
+(Tú) ¡______ (ir) a tu habitación ahora mismo!;ve
+(Usted) ______ (ir) con cuidado por la calle.;vaya
+(Nosotros) ______ (ir) al parque a jugar.;vamos
+(Vosotros) ¡______ (ir) a casa, ya es tarde!;id
+(Ustedes) ______ (ir) a la recepción para registrarse.;vayan

--- a/lang_data/ir/imperfecto.txt
+++ b/lang_data/ir/imperfecto.txt
@@ -1,0 +1,6 @@
+Cuando era niño, yo ______ (ir) al parque todos los días.;iba
+Tú ______ (ir) a la casa de tu abuela los domingos.;ibas
+Él ______ (ir) a clases de piano los martes.;iba
+Nosotros ______ (ir) juntos a la escuela primaria.;íbamos
+Vosotros ______ (ir) de campamento en verano.;ibais
+Ellos ______ (ir) al cine con frecuencia.;iban

--- a/lang_data/ir/pluscuamperfecto.txt
+++ b/lang_data/ir/pluscuamperfecto.txt
@@ -1,0 +1,6 @@
+Yo ya ______ (ir) al supermercado cuando me llamaste.;había ido
+Tú ______ (ir) al banco antes de que cerrara, ¿verdad?;habías ido
+Él ______ (ir) a la oficina temprano ese día.;había ido
+Nosotros ______ (ir) a ese restaurante antes, pero no nos gustó.;habíamos ido
+Vosotros ya ______ (ir) de vacaciones cuando os avisaron del problema.;habíais ido
+Ellos ______ (ir) al aeropuerto con mucho tiempo de antelación.;habían ido

--- a/lang_data/ir/presente.txt
+++ b/lang_data/ir/presente.txt
@@ -1,0 +1,6 @@
+Yo ______ (ir) al mercado todos los sábados.;voy
+Tú ______ (ir) a la escuela en autobús.;vas
+Ella ______ (ir) al gimnasio por las tardes.;va
+Nosotros ______ (ir) de vacaciones a la playa en verano.;vamos
+Vosotros ______ (ir) al cine esta noche.;vais
+Ustedes ______ (ir) a la reunión de padres.;van

--- a/lang_data/ir/preterito_indefinido.txt
+++ b/lang_data/ir/preterito_indefinido.txt
@@ -1,0 +1,6 @@
+Ayer yo ______ (ir) al cine con mis amigos.;fui
+¿Adónde ______ (ir) tú de vacaciones el año pasado?;fuiste
+Él ______ (ir) a la biblioteca a estudiar.;fue
+Nosotros ______ (ir) a la montaña el fin de semana pasado.;fuimos
+Vosotros ______ (ir) al concierto de rock anoche.;fuisteis
+Ellos ______ (ir) de excursión al campo.;fueron

--- a/lang_data/ir/preterito_perfecto_compuesto.txt
+++ b/lang_data/ir/preterito_perfecto_compuesto.txt
@@ -1,0 +1,6 @@
+Este año yo ______ (ir) a tres bodas.;he ido
+¿Alguna vez tú ______ (ir) a Asia?;has ido
+Ella ______ (ir) a la tienda a comprar pan.;ha ido
+Nosotros ______ (ir) muchas veces a ese restaurante.;hemos ido
+Vosotros nunca ______ (ir) al museo de cera.;habéis ido
+Ellos ______ (ir) al extranjero por trabajo.;han ido

--- a/lang_data/ir/subjuntivo_imperfecto_ra.txt
+++ b/lang_data/ir/subjuntivo_imperfecto_ra.txt
@@ -1,0 +1,6 @@
+Si yo ______ (ir) a la fiesta, te habría visto.;fuera
+Si tú ______ (ir) más despacio, no te habrías caído.;fueras
+Si él ______ (ir) al médico antes, no estaría tan enfermo.;fuera
+Si nosotros ______ (ir) de vacaciones juntos, nos divertiríamos mucho.;fuéramos
+Si vosotros ______ (ir) al concierto, necesitaríais comprar entradas.;fuerais
+Si ellos ______ (ir) a la reunión, podrían dar su opinión.;fueran

--- a/lang_data/ir/subjuntivo_presente.txt
+++ b/lang_data/ir/subjuntivo_presente.txt
@@ -1,0 +1,6 @@
+Espero que yo ______ (ir) a la fiesta esta noche.;vaya
+Es importante que tú ______ (ir) al médico para un chequeo.;vayas
+Es posible que él ______ (ir) de vacaciones a Italia.;vaya
+Es necesario que nosotros ______ (ir) preparados para la reunión.;vayamos
+Dudo que vosotros ______ (ir) a terminar el proyecto a tiempo.;vayáis
+Es probable que ellos ______ (ir) al concierto si consiguen entradas.;vayan

--- a/lang_data/poder/condicional.txt
+++ b/lang_data/poder/condicional.txt
@@ -1,0 +1,6 @@
+Si tuviera más dinero, yo ______ (poder) comprar un coche.;podría
+Tú ______ (poder) ayudarme si tuvieras tiempo, ¿verdad?;podrías
+Él ______ (poder) ser un gran atleta si entrenara más.;podría
+Nosotros ______ (poder) ir al concierto si consiguiéramos entradas.;podríamos
+Vosotros ______ (poder) aprender cualquier cosa si os lo propusierais.;podríais
+Ellos ______ (poder) viajar por el mundo si ganaran la lotería.;podrían

--- a/lang_data/poder/futuro.txt
+++ b/lang_data/poder/futuro.txt
@@ -1,0 +1,6 @@
+Mañana yo ______ (poder) visitarte.;podré
+Con más práctica, tú ______ (poder) tocar el piano.;podrás
+Él ______ (poder) unirse a nosotros más tarde.;podrá
+Nosotros ______ (poder) ver la película el próximo fin de semana.;podremos
+Vosotros ______ (poder) alcanzar vuestros objetivos si os esforzáis.;podréis
+Ellos ______ (poder) resolver el problema si trabajan juntos.;podrán

--- a/lang_data/poder/imperativo_afirmativo.txt
+++ b/lang_data/poder/imperativo_afirmativo.txt
@@ -1,0 +1,5 @@
+(Tú) ¡______ (poder) hacerlo si te esfuerzas!;puede
+(Usted) ______ (poder) usted tomar la iniciativa en este asunto.;pueda
+(Nosotros) ______ (poder) nosotros encontrar una solución juntos.;podamos
+(Vosotros) ¡______ (poder) vosotros superar este desafío!;poded
+(Ustedes) ______ (poder) ustedes marcar la diferencia con su contribución.;puedan

--- a/lang_data/poder/imperfecto.txt
+++ b/lang_data/poder/imperfecto.txt
@@ -1,0 +1,6 @@
+De niño, yo no ______ (poder) nadar muy bien.;podía
+Tú ______ (poder) correr más rápido cuando eras más joven.;podías
+Ella ______ (poder) cantar canciones muy bonitas.;podía
+Nosotros ______ (poder) jugar en el parque durante horas.;podíamos
+Vosotros ______ (poder) venir a visitarnos más a menudo.;podíais
+Ellos ______ (poder) ver el mar desde su antigua casa.;podían

--- a/lang_data/poder/pluscuamperfecto.txt
+++ b/lang_data/poder/pluscuamperfecto.txt
@@ -1,0 +1,6 @@
+Yo ya ______ (poder) caminar largas distancias antes de la lesión.;había podido
+Tú ______ (poder) resolver el acertijo antes de que te dieran la pista.;habías podido
+Ella ______ (poder) terminar el maratón el año anterior.;había podido
+Nosotros ______ (poder) comprar la casa antes de que los precios subieran.;habíamos podido
+Vosotros ______ (poder) visitar el museo antes de que cerrara por reformas.;habíais podido
+Ellos ______ (poder) escapar antes de que llegara la tormenta.;habían podido

--- a/lang_data/poder/presente.txt
+++ b/lang_data/poder/presente.txt
@@ -1,0 +1,6 @@
+Yo ______ (poder) levantar objetos pesados.;puedo
+Tú ______ (poder) correr muy rápido.;puedes
+Ella ______ (poder) hablar tres idiomas.;puede
+Nosotros ______ (poder) ayudarte con la mudanza.;podemos
+Vosotros ______ (poder) resolver este problema.;podéis
+Ustedes ______ (poder) venir a la fiesta si quieren.;pueden

--- a/lang_data/poder/preterito_indefinido.txt
+++ b/lang_data/poder/preterito_indefinido.txt
@@ -1,0 +1,6 @@
+Ayer yo no ______ (poder) ir al cine.;pude
+Anoche tú ______ (poder) terminar el libro.;pudiste
+Él ______ (poder) levantar la caja pesada sin ayuda.;pudo
+Nosotros ______ (poder) llegar a tiempo a pesar del tráfico.;pudimos
+Vosotros ______ (poder) resolver el problema con ingenio.;pudisteis
+Ellos no ______ (poder) asistir a la reunión por un imprevisto.;pudieron

--- a/lang_data/poder/preterito_perfecto_compuesto.txt
+++ b/lang_data/poder/preterito_perfecto_compuesto.txt
@@ -1,0 +1,6 @@
+Yo nunca ______ (poder) entender las matemáticas complejas.;he podido
+Tú ______ (poder) superar todos los obstáculos hasta ahora.;has podido
+Ella ______ (poder) terminar el proyecto a tiempo.;ha podido
+Nosotros ______ (poder) ahorrar suficiente dinero para el viaje.;hemos podido
+Vosotros ______ (poder) ver la película antes que nadie.;habéis podido
+Ellos ______ (poder) resolver el misterio gracias a las pistas.;han podido

--- a/lang_data/poder/subjuntivo_imperfecto_ra.txt
+++ b/lang_data/poder/subjuntivo_imperfecto_ra.txt
@@ -1,0 +1,6 @@
+Si yo ______ (poder) volar, viajaría a la luna.;pudiera
+Si tú ______ (poder) leer mentes, ¿qué harías?;pudieras
+Si él ______ (poder) cambiar el pasado, lo haría.;pudiera
+Si nosotros ______ (poder) ayudar más, lo haríamos con gusto.;pudiéramos
+Si vosotros ______ (poder) elegir cualquier superpoder, ¿cuál sería?;pudierais
+Si ellos ______ (poder) venir antes, nos encontrarían aquí.;pudieran

--- a/lang_data/poder/subjuntivo_presente.txt
+++ b/lang_data/poder/subjuntivo_presente.txt
@@ -1,0 +1,6 @@
+Espero que yo ______ (poder) ayudarte con tu proyecto.;pueda
+Es necesario que tú ______ (poder) concentrarte en tus estudios.;puedas
+Es posible que ella ______ (poder) venir a la fiesta mañana.;pueda
+Es importante que nosotros ______ (poder) encontrar una solución pronto.;podamos
+Dudo que vosotros ______ (poder) terminar el trabajo hoy mismo.;podáis
+Es probable que ellos ______ (poder) ganar el campeonato.;puedan

--- a/lang_data/saber/condicional.txt
+++ b/lang_data/saber/condicional.txt
@@ -1,0 +1,6 @@
+Si estudiara más, yo ______ (saber) la respuesta.;sabría
+¿Tú ______ (saber) qué hacer en una emergencia como esa?;sabrías
+Él ______ (saber) la verdad si se la contaras.;sabría
+Nosotros ______ (saber) cómo ayudar si conociéramos el problema.;sabríamos
+Vosotros ______ (saber) la solución si pensarais un poco más.;sabríais
+Ellos ______ (saber) qué decir si estuvieran en nuestro lugar.;sabrían

--- a/lang_data/saber/futuro.txt
+++ b/lang_data/saber/futuro.txt
@@ -1,0 +1,6 @@
+Mañana yo ______ (saber) los resultados del examen.;sabré
+¿Cuándo ______ (saber) tú la fecha del viaje?;sabrás
+Él ______ (saber) la respuesta cuando termine de investigar.;sabrá
+Nosotros ______ (saber) qué hacer después de la reunión.;sabremos
+Vosotros ______ (saber) la verdad en algún momento.;sabréis
+Ellos ______ (saber) cómo solucionar el problema.;sabrán

--- a/lang_data/saber/imperativo_afirmativo.txt
+++ b/lang_data/saber/imperativo_afirmativo.txt
@@ -1,0 +1,5 @@
+(Tú) ¡______ (saber) la lección para mañana!;sabe
+(Usted) ______ (saber) que esto es confidencial.;sepa
+(Nosotros) ______ (saber) cómo actuar en caso de emergencia.;sepamos
+(Vosotros) ¡______ (saber) las reglas antes de jugar!;sabed
+(Ustedes) ______ (saber) que estamos aquí para ayudarles.;sepan

--- a/lang_data/saber/imperfecto.txt
+++ b/lang_data/saber/imperfecto.txt
@@ -1,0 +1,6 @@
+De niño, yo no ______ (saber) nadar.;sabía
+Tú ______ (saber) que eso iba a pasar, ¿verdad?;sabías
+Él ______ (saber) la lección de memoria.;sabía
+Nosotros ______ (saber) que teníamos que estudiar más.;sabíamos
+Vosotros ______ (saber) la respuesta, pero no la dijisteis.;sabíais
+Ellos ______ (saber) que el camino era peligroso.;sabían

--- a/lang_data/saber/pluscuamperfecto.txt
+++ b/lang_data/saber/pluscuamperfecto.txt
@@ -1,0 +1,6 @@
+Yo ya ______ (saber) la respuesta antes de que la preguntaras.;había sabido
+Tú ______ (saber) que él vendría, ¿por qué te sorprendiste?;habías sabido
+Ella ______ (saber) desde el principio que no era una buena idea.;había sabido
+Nosotros ______ (saber) que tendríamos problemas con este proyecto.;habíamos sabido
+Vosotros ______ (saber) la combinación de la caja fuerte todo el tiempo.;habíais sabido
+Ellos ______ (saber) del riesgo, pero decidieron continuar.;habían sabido

--- a/lang_data/saber/presente.txt
+++ b/lang_data/saber/presente.txt
@@ -1,0 +1,6 @@
+Yo ______ (saber) la respuesta a esa pregunta.;sé
+Tú ______ (saber) hablar francés muy bien.;sabes
+Ella ______ (saber) cocinar paella.;sabe
+Nosotros ______ (saber) que tenemos un examen mañana.;sabemos
+Vosotros ______ (saber) dónde está la biblioteca, ¿verdad?;sabéis
+Ustedes ______ (saber) mucho sobre historia del arte.;saben

--- a/lang_data/saber/preterito_indefinido.txt
+++ b/lang_data/saber/preterito_indefinido.txt
@@ -1,0 +1,6 @@
+Ayer yo ______ (saber) la noticia por la radio.;supe
+¿Cuándo ______ (saber) tú que te ibas a mudar?;supiste
+Él ______ (saber) la verdad cuando leyó la carta.;supo
+Nosotros ______ (saber) del accidente por un amigo en común.;supimos
+Vosotros ______ (saber) que habíais aprobado el examen esta mañana.;supisteis
+Ellos ______ (saber) cómo reaccionar en esa situación de emergencia.;supieron

--- a/lang_data/saber/preterito_perfecto_compuesto.txt
+++ b/lang_data/saber/preterito_perfecto_compuesto.txt
@@ -1,0 +1,6 @@
+Yo siempre ______ (saber) la verdad sobre ese asunto.;he sabido
+Tú ______ (saber) la respuesta todo este tiempo, ¿no?;has sabido
+Ella ______ (saber) cómo resolver el problema desde el principio.;ha sabido
+Nosotros ______ (saber) los resultados del examen esta mañana.;hemos sabido
+Vosotros ______ (saber) la noticia antes que nadie.;habéis sabido
+Ellos ______ (saber) de su llegada con antelación.;han sabido

--- a/lang_data/saber/subjuntivo_imperfecto_ra.txt
+++ b/lang_data/saber/subjuntivo_imperfecto_ra.txt
@@ -1,0 +1,6 @@
+Si yo ______ (saber) la respuesta, te la diría.;supiera
+Si tú ______ (saber) la verdad, cambiarías de opinión.;supieras
+Si él ______ (saber) nadar, iría a la piscina.;supiera
+Si nosotros ______ (saber) dónde está, iríamos a buscarlo.;supiéramos
+Si vosotros ______ (saber) el secreto, ¿lo guardaríais?;supierais
+Si ellos ______ (saber) las consecuencias, no lo harían.;supieran

--- a/lang_data/saber/subjuntivo_presente.txt
+++ b/lang_data/saber/subjuntivo_presente.txt
@@ -1,0 +1,6 @@
+Espero que yo ______ (saber) la respuesta correcta en el examen.;sepa
+Es importante que tú ______ (saber) la verdad sobre este asunto.;sepas
+Es posible que ella ______ (saber) dónde encontrarlo.;sepa
+Es necesario que nosotros ______ (saber) cómo funciona el sistema.;sepamos
+Dudo que vosotros ______ (saber) toda la historia completa.;sepáis
+Es probable que ellos ______ (saber) la noticia mañana.;sepan

--- a/lang_data/ser/condicional.txt
+++ b/lang_data/ser/condicional.txt
@@ -1,0 +1,6 @@
+Si tuviera más dinero, yo ______ (ser) más generoso.;sería
+Tú ______ (ser) un excelente líder si te lo propusieras.;serías
+Él ______ (ser) más feliz si viviera cerca del mar.;sería
+Nosotros ______ (ser) los primeros en ayudar si nos necesitaran.;seríamos
+Con más práctica, vosotros ______ (ser) imparables.;seríais
+Ellos ______ (ser) más amigables si no estuvieran tan cansados.;serían

--- a/lang_data/ser/futuro.txt
+++ b/lang_data/ser/futuro.txt
@@ -1,0 +1,6 @@
+Mañana yo ______ (ser) el primero en llegar.;seré
+En el futuro, tú ______ (ser) un gran profesional.;serás
+La próxima semana, el evento ______ (ser) en el auditorio.;será
+Nosotros ______ (ser) más cuidadosos la próxima vez.;seremos
+Vosotros ______ (ser) los responsables del proyecto.;seréis
+Ellos ______ (ser) los ganadores si se esfuerzan.;serán

--- a/lang_data/ser/imperativo_afirmativo.txt
+++ b/lang_data/ser/imperativo_afirmativo.txt
@@ -1,0 +1,5 @@
+(Tú) ¡______ (ser) bueno y pórtate bien!;sé
+(Usted) ______ (ser) amable con los clientes.;sea
+(Nosotros) ______ (ser) un ejemplo para los demás.;seamos
+(Vosotros) ¡______ (ser) valientes y no tengáis miedo!;sed
+(Ustedes) ______ (ser) bienvenidos a la reunión.;sean

--- a/lang_data/ser/imperfecto.txt
+++ b/lang_data/ser/imperfecto.txt
@@ -1,0 +1,6 @@
+Cuando yo era niño, ______ (ser) muy travieso.;era
+Tú ______ (ser) un buen estudiante en la escuela primaria.;eras
+Él ______ (ser) el capitán del equipo.;era
+Nosotros ______ (ser) los únicos que hablaban español en la clase.;éramos
+Vosotros ______ (ser) muy unidos en aquel entonces.;erais
+Ellos ______ (ser) felices con poco.;eran

--- a/lang_data/ser/pluscuamperfecto.txt
+++ b/lang_data/ser/pluscuamperfecto.txt
@@ -1,0 +1,6 @@
+Antes de la mudanza, yo ya ______ (ser) notificado del cambio.;había sido
+Tú ______ (ser) advertido varias veces antes del incidente.;habías sido
+Cuando llegamos, él ya ______ (ser) el director por cinco años.;había sido
+Nosotros ______ (ser) amigos desde la infancia hasta ese momento.;habíamos sido
+Vosotros ya ______ (ser) informados cuando os llamé.;habíais sido
+Ellos ______ (ser) muy unidos antes de la discusión.;habían sido

--- a/lang_data/ser/presente.txt
+++ b/lang_data/ser/presente.txt
@@ -1,0 +1,6 @@
+Yo ______ (ser) un estudiante.;soy
+Tú ______ (ser) muy inteligente.;eres
+Él ______ (ser) doctor.;es
+Nosotros ______ (ser) amigos.;somos
+Vosotros ______ (ser) de España.;sois
+Ellos ______ (ser) altos.;son

--- a/lang_data/ser/preterito_indefinido.txt
+++ b/lang_data/ser/preterito_indefinido.txt
@@ -1,0 +1,6 @@
+Ayer yo ______ (ser) el único en la oficina.;fui
+Anoche tú ______ (ser) el alma de la fiesta.;fuiste
+El mes pasado, él ______ (ser) promovido a gerente.;fue
+Nosotros ______ (ser) compañeros de clase en 2010.;fuimos
+Vosotros ______ (ser) los fundadores de la empresa.;fuisteis
+Ellos ______ (ser) muy amables con nosotros durante la visita.;fueron

--- a/lang_data/ser/preterito_perfecto_compuesto.txt
+++ b/lang_data/ser/preterito_perfecto_compuesto.txt
@@ -1,0 +1,6 @@
+Hoy yo ______ (ser) muy productivo.;he sido
+Esta semana tú ______ (ser) de gran ayuda.;has sido
+Él siempre ______ (ser) un buen amigo.;ha sido
+Nosotros ______ (ser) consistentes con nuestro trabajo.;hemos sido
+Vosotros ______ (ser) los mejores en la competencia.;habéis sido
+Ellos ______ (ser) informados sobre la situación.;han sido

--- a/lang_data/ser/subjuntivo_imperfecto_ra.txt
+++ b/lang_data/ser/subjuntivo_imperfecto_ra.txt
@@ -1,0 +1,6 @@
+Si yo ______ (ser) más alto, jugaría baloncesto.;fuera
+Si tú ______ (ser) más paciente, entenderías mejor.;fueras
+Si él ______ (ser) el jefe, cambiaría muchas cosas.;fuera
+Si nosotros ______ (ser) más ricos, viajaríamos por el mundo.;fuéramos
+Si vosotros ______ (ser) más organizados, terminaríais antes.;fuerais
+Si ellos ______ (ser) menos ruidosos, podríamos concentrarnos.;fueran

--- a/lang_data/ser/subjuntivo_presente.txt
+++ b/lang_data/ser/subjuntivo_presente.txt
@@ -1,0 +1,6 @@
+Espero que yo ______ (ser) una buena influencia.;sea
+Es importante que tú ______ (ser) honesto.;seas
+Dudo que él ______ (ser) el culpable.;sea
+Es necesario que nosotros ______ (ser) puntuales.;seamos
+Es posible que vosotros ______ (ser) los elegidos.;seáis
+Es probable que ellos ______ (ser) promovidos.;sean

--- a/lang_data/tener/condicional.txt
+++ b/lang_data/tener/condicional.txt
@@ -1,0 +1,6 @@
+Si yo fuera rico, ______ (tener) un yate.;tendría
+Tú ______ (tener) más éxito si trabajaras más duro.;tendrías
+Él ______ (tener) mejores notas si estudiara más.;tendría
+Nosotros ______ (tener) una casa en la playa si ahorráramos.;tendríamos
+Vosotros ______ (tener) menos problemas si fuerais más cuidadosos.;tendríais
+Ellos ______ (tener) más amigos si fueran más sociables.;tendrían

--- a/lang_data/tener/futuro.txt
+++ b/lang_data/tener/futuro.txt
@@ -1,0 +1,6 @@
+Mañana yo ______ (tener) más tiempo libre.;tendré
+El próximo año tú ______ (tener) nuevas responsabilidades.;tendrás
+Él ______ (tener) que tomar una decisión importante.;tendrá
+Nosotros ______ (tener) una reunión con el director la próxima semana.;tendremos
+Vosotros ______ (tener) la oportunidad de demostrar vuestro talento.;tendréis
+Ellos ______ (tener) que adaptarse a los cambios.;tendrán

--- a/lang_data/tener/imperativo_afirmativo.txt
+++ b/lang_data/tener/imperativo_afirmativo.txt
@@ -1,0 +1,5 @@
+(Tú) ¡______ (tener) cuidado con el perro!;ten
+(Usted) ______ (tener) paciencia, por favor.;tenga
+(Nosotros) ______ (tener) fe en que todo saldrá bien.;tengamos
+(Vosotros) ¡______ (tener) un buen viaje!;tened
+(Ustedes) ______ (tener) en cuenta las recomendaciones.;tengan

--- a/lang_data/tener/imperfecto.txt
+++ b/lang_data/tener/imperfecto.txt
@@ -1,0 +1,6 @@
+Cuando era niño, yo ______ (tener) un perro.;tenía
+Antes, tú ______ (tener) el pelo más largo.;tenías
+Él ______ (tener) una bicicleta roja cuando era pequeño.;tenía
+Nosotros ______ (tener) muchos amigos en la vieja escuela.;teníamos
+Vosotros siempre ______ (tener) juguetes interesantes.;teníais
+Ellos ______ (tener) una casa cerca del mar.;tenían

--- a/lang_data/tener/pluscuamperfecto.txt
+++ b/lang_data/tener/pluscuamperfecto.txt
@@ -1,0 +1,6 @@
+Antes de ganar la lotería, yo nunca ______ (tener) tanto dinero.;había tenido
+Tú ya ______ (tener) experiencia en ese campo antes de aplicar.;habías tenido
+Él ______ (tener) varios coches antes de comprar el actual.;había tenido
+Nosotros ______ (tener) problemas similares en el pasado.;habíamos tenido
+Vosotros ______ (tener) esa discusión muchas veces antes.;habíais tenido
+Ellos ______ (tener) la oportunidad de conocerlo antes del evento.;habían tenido

--- a/lang_data/tener/presente.txt
+++ b/lang_data/tener/presente.txt
@@ -1,0 +1,6 @@
+Yo ______ (tener) un coche nuevo.;tengo
+Tú ______ (tener) mucha suerte.;tienes
+Ella ______ (tener) dos hermanos.;tiene
+Nosotros ______ (tener) una casa grande.;tenemos
+Vosotros ______ (tener) hambre.;tenéis
+Ustedes ______ (tener) que estudiar más.;tienen

--- a/lang_data/tener/preterito_indefinido.txt
+++ b/lang_data/tener/preterito_indefinido.txt
@@ -1,0 +1,6 @@
+Ayer yo ______ (tener) un examen muy difícil.;tuve
+Anoche tú ______ (tener) una pesadilla.;tuviste
+El año pasado él ______ (tener) un accidente de coche.;tuvo
+Nosotros ______ (tener) una reunión importante esta mañana.;tuvimos
+Vosotros ______ (tener) que esperar mucho tiempo en la fila.;tuvisteis
+Ellos ______ (tener) una gran fiesta para su aniversario.;tuvieron

--- a/lang_data/tener/preterito_perfecto_compuesto.txt
+++ b/lang_data/tener/preterito_perfecto_compuesto.txt
@@ -1,0 +1,6 @@
+Hoy yo ______ (tener) un día muy ocupado.;he tenido
+Esta semana tú ______ (tener) muchos exámenes.;has tenido
+Él siempre ______ (tener) el apoyo de su familia.;ha tenido
+Nosotros ______ (tener) algunos problemas con el coche.;hemos tenido
+Vosotros ______ (tener) la oportunidad de viajar mucho.;habéis tenido
+Ellos ______ (tener) que trabajar hasta tarde hoy.;han tenido

--- a/lang_data/tener/subjuntivo_imperfecto_ra.txt
+++ b/lang_data/tener/subjuntivo_imperfecto_ra.txt
@@ -1,0 +1,6 @@
+Si yo ______ (tener) más dinero, viajaría más.;tuviera
+Si tú ______ (tener) más cuidado, no te lastimarías.;tuvieras
+Si él ______ (tener) más tiempo, nos ayudaría.;tuviera
+Si nosotros ______ (tener) un coche, iríamos a la playa.;tuviéramos
+Si vosotros ______ (tener) la oportunidad, ¿la aprovecharíais?;tuvierais
+Si ellos ______ (tener) más información, tomarían una decisión.;tuvieran

--- a/lang_data/tener/subjuntivo_presente.txt
+++ b/lang_data/tener/subjuntivo_presente.txt
@@ -1,0 +1,6 @@
+Espero que yo ______ (tener) buenas noticias pronto.;tenga
+Es importante que tú ______ (tener) paciencia.;tengas
+Es posible que ella ______ (tener) razón.;tenga
+Es necesario que nosotros ______ (tener) un plan.;tengamos
+Dudo que vosotros ______ (tener) tiempo suficiente.;tengáis
+Es probable que ellos ______ (tener) algunas preguntas.;tengan

--- a/lang_data/ver/condicional.txt
+++ b/lang_data/ver/condicional.txt
@@ -1,0 +1,6 @@
+Si tuviera gafas, yo ______ (ver) mejor la pizarra.;vería
+¿Tú ______ (ver) esa película de miedo solo en casa?;verías
+Él ______ (ver) el partido si no tuviera que trabajar.;vería
+Nosotros ______ (ver) el amanecer si nos levantáramos temprano.;veríamos
+Vosotros ______ (ver) las estrellas si no estuviera nublado.;veríais
+Ellos ______ (ver) la obra de teatro si consiguieran entradas.;verían

--- a/lang_data/ver/futuro.txt
+++ b/lang_data/ver/futuro.txt
@@ -1,0 +1,6 @@
+Mañana yo ______ (ver) a mis abuelos.;veré
+¿Cuándo ______ (ver) tú los resultados del examen?;verás
+Él ______ (ver) el partido en casa de un amigo.;verá
+Nosotros ______ (ver) la nueva exposición en el museo.;veremos
+Vosotros ______ (ver) si podéis venir a la fiesta.;veréis
+Ellos ______ (ver) la película en el cine este fin de semana.;verán

--- a/lang_data/ver/imperativo_afirmativo.txt
+++ b/lang_data/ver/imperativo_afirmativo.txt
@@ -1,0 +1,5 @@
+(Tú) ¡______ (ver) qué bonito paisaje!;ve
+(Usted) ______ (ver) la demostración con atención.;vea
+(Nosotros) ______ (ver) si podemos ayudar en algo.;veamos
+(Vosotros) ¡______ (ver) la película, es muy buena!;ved
+(Ustedes) ______ (ver) las instrucciones antes de empezar.;vean

--- a/lang_data/ver/imperfecto.txt
+++ b/lang_data/ver/imperfecto.txt
@@ -1,0 +1,6 @@
+Cuando era niño, yo ______ (ver) dibujos animados todas las tardes.;veía
+Tú ______ (ver) a tus abuelos todos los fines de semana.;veías
+Él ______ (ver) el mar desde la ventana de su habitación.;veía
+Nosotros ______ (ver) las estrellas fugaces en las noches de verano.;veíamos
+Vosotros ______ (ver) los partidos de vuestro equipo favorito juntos.;veíais
+Ellos ______ (ver) el desfile desde el balcón de su casa.;veían

--- a/lang_data/ver/pluscuamperfecto.txt
+++ b/lang_data/ver/pluscuamperfecto.txt
@@ -1,0 +1,6 @@
+Yo ya ______ (ver) la película antes de que me la recomendaras.;había visto
+Tú ______ (ver) el accidente antes de que llegara la policía.;habías visto
+Él ______ (ver) esa obra de teatro varias veces.;había visto
+Nosotros ______ (ver) el arcoíris después de la tormenta.;habíamos visto
+Vosotros ______ (ver) el anuncio en la televisión antes de comprar el producto.;habíais visto
+Ellos ______ (ver) al ladrón escapar antes de que sonara la alarma.;habían visto

--- a/lang_data/ver/presente.txt
+++ b/lang_data/ver/presente.txt
@@ -1,0 +1,6 @@
+Yo ______ (ver) las noticias todas las mañanas.;veo
+Tú ______ (ver) películas de terror los fines de semana.;ves
+Ella ______ (ver) a sus amigos después de clase.;ve
+Nosotros ______ (ver) un partido de fútbol en la televisión.;vemos
+Vosotros ______ (ver) las estrellas desde el balcón.;veis
+Ustedes ______ (ver) el amanecer desde la montaña.;ven

--- a/lang_data/ver/preterito_indefinido.txt
+++ b/lang_data/ver/preterito_indefinido.txt
@@ -1,0 +1,6 @@
+Ayer yo ______ (ver) una estrella fugaz en el cielo.;vi
+¿Qué película ______ (ver) tú anoche en el cine?;viste
+Él ______ (ver) el accidente desde su ventana.;vio
+Nosotros ______ (ver) un documental muy interesante sobre la naturaleza.;vimos
+Vosotros ______ (ver) el partido de baloncesto en directo.;visteis
+Ellos ______ (ver) a sus abuelos durante las vacaciones.;vieron

--- a/lang_data/ver/preterito_perfecto_compuesto.txt
+++ b/lang_data/ver/preterito_perfecto_compuesto.txt
@@ -1,0 +1,6 @@
+Yo ______ (ver) esa película tres veces.;he visto
+¿Tú ______ (ver) el último episodio de la serie?;has visto
+Ella ______ (ver) un fantasma en la casa abandonada.;ha visto
+Nosotros ______ (ver) muchos cambios en la ciudad últimamente.;hemos visto
+Vosotros ______ (ver) el cometa pasar esta noche, ¿verdad?;habéis visto
+Ellos ______ (ver) el partido en el estadio.;han visto

--- a/lang_data/ver/subjuntivo_imperfecto_ra.txt
+++ b/lang_data/ver/subjuntivo_imperfecto_ra.txt
@@ -1,0 +1,6 @@
+Si yo ______ (ver) un fantasma, gritaría.;viera
+Si tú ______ (ver) a Juan, ¿le dirías que lo estoy buscando?;vieras
+Si él ______ (ver) la oportunidad, la aprovecharía.;viera
+Si nosotros ______ (ver) el peligro, nos protegeríamos.;viéramos
+Si vosotros ______ (ver) un accidente, llamaríais a emergencias.;vierais
+Si ellos ______ (ver) el problema, intentarían solucionarlo.;vieran

--- a/lang_data/ver/subjuntivo_presente.txt
+++ b/lang_data/ver/subjuntivo_presente.txt
@@ -1,0 +1,6 @@
+Espero que yo ______ (ver) a mis amigos en la fiesta.;vea
+Es importante que tú ______ (ver) al médico por ese dolor.;veas
+Es posible que ella ______ (ver) la película esta noche.;vea
+Es necesario que nosotros ______ (ver) todas las opciones antes de decidir.;veamos
+Dudo que vosotros ______ (ver) el final de la serie hoy.;veáis
+Es probable que ellos ______ (ver) el partido en el bar.;vean

--- a/scripts/build-data.mjs
+++ b/scripts/build-data.mjs
@@ -7,9 +7,11 @@ const outputFilePath = path.resolve(process.cwd(), 'src/data.ts');
 
 // Basic tense groupings (customize as needed)
 const tenseGroups = {
-    present: ['presente'],
-    past: ['pretérito', 'imperfecto'], // Add more past tenses if you have them
+    present: ['presente', 'subjuntivo_presente'],
+    past: ['imperfecto', 'preterito_indefinido', 'preterito_perfecto_compuesto', 'pluscuamperfecto', 'subjuntivo_imperfecto_ra'],
     future: ['futuro'],
+    conditional: ['condicional'],
+    imperative: ['imperativo_afirmativo']
 };
 
 async function parseSentenceFile(filePath) {

--- a/src/data.ts
+++ b/src/data.ts
@@ -58,6 +58,780 @@ export const languageData: LanguageData = {
       }
     ]
   },
+  "dar": {
+    "condicional": [
+      {
+        "template": "Si tuviera más dinero, yo ______ (dar) una gran fiesta.",
+        "answer": "daría"
+      },
+      {
+        "template": "¿Tú le ______ (dar) una segunda oportunidad si te la pidiera?",
+        "answer": "darías"
+      },
+      {
+        "template": "Él ______ (dar) cualquier cosa por volver a verla.",
+        "answer": "daría"
+      },
+      {
+        "template": "Nosotros ______ (dar) un donativo si la causa fuera justa.",
+        "answer": "daríamos"
+      },
+      {
+        "template": "Vosotros ______ (dar) mejores regalos si tuvierais más imaginación.",
+        "answer": "daríais"
+      },
+      {
+        "template": "Ellos ______ (dar) la vuelta al mundo si pudieran.",
+        "answer": "darían"
+      }
+    ],
+    "futuro": [
+      {
+        "template": "Mañana yo te ______ (dar) mi respuesta definitiva.",
+        "answer": "daré"
+      },
+      {
+        "template": "¿Cuándo me ______ (dar) tú el dinero que me debes?",
+        "answer": "darás"
+      },
+      {
+        "template": "Él le ______ (dar) una sorpresa a su novia por su aniversario.",
+        "answer": "dará"
+      },
+      {
+        "template": "Nosotros ______ (dar) un concierto en el auditorio municipal.",
+        "answer": "daremos"
+      },
+      {
+        "template": "Vosotros ______ (dar) vuestra opinión en la próxima reunión.",
+        "answer": "daréis"
+      },
+      {
+        "template": "Ellos ______ (dar) una conferencia sobre el cambio climático.",
+        "answer": "darán"
+      }
+    ],
+    "imperativo_afirmativo": [
+      {
+        "template": "(Tú) ¡______ (dar) las gracias cuando recibas algo!",
+        "answer": "da"
+      },
+      {
+        "template": "(Usted) ______ (dar) un discurso inspirador en la conferencia.",
+        "answer": "dé"
+      },
+      {
+        "template": "(Nosotros) ______ (dar) la bienvenida a los nuevos miembros.",
+        "answer": "demos"
+      },
+      {
+        "template": "(Vosotros) ¡______ (dar) lo mejor de vosotros en el partido!",
+        "answer": "dad"
+      },
+      {
+        "template": "(Ustedes) ______ (dar) sus opiniones durante la reunión.",
+        "answer": "den"
+      }
+    ],
+    "imperfecto": [
+      {
+        "template": "Cuando era niño, yo siempre ______ (dar) problemas a mis padres.",
+        "answer": "daba"
+      },
+      {
+        "template": "Tú ______ (dar) largos paseos por la playa en verano.",
+        "answer": "dabas"
+      },
+      {
+        "template": "Él ______ (dar) de comer a su perro todas las mañanas.",
+        "answer": "daba"
+      },
+      {
+        "template": "Nosotros ______ (dar) una vuelta por el pueblo los domingos.",
+        "answer": "dábamos"
+      },
+      {
+        "template": "Vosotros ______ (dar) regalos a vuestros amigos en Navidad.",
+        "answer": "dabais"
+      },
+      {
+        "template": "Ellos ______ (dar) clases de baile en la escuela del barrio.",
+        "answer": "daban"
+      }
+    ],
+    "pluscuamperfecto": [
+      {
+        "template": "Yo ya le ______ (dar) el regalo antes de que llegara.",
+        "answer": "había dado"
+      },
+      {
+        "template": "Tú ______ (dar) tu palabra, no podías retractarte.",
+        "answer": "habías dado"
+      },
+      {
+        "template": "Él nos ______ (dar) su apoyo incondicional desde el principio.",
+        "answer": "había dado"
+      },
+      {
+        "template": "Nosotros ______ (dar) por sentado que vendrían a la fiesta.",
+        "answer": "habíamos dado"
+      },
+      {
+        "template": "Vosotros ______ (dar) la señal de alarma antes de que fuera tarde.",
+        "answer": "habíais dado"
+      },
+      {
+        "template": "Ellos ______ (dar) una respuesta afirmativa la semana anterior.",
+        "answer": "habían dado"
+      }
+    ],
+    "presente": [
+      {
+        "template": "Yo siempre ______ (dar) regalos en los cumpleaños.",
+        "answer": "doy"
+      },
+      {
+        "template": "Tú ______ (dar) muy buenos consejos.",
+        "answer": "das"
+      },
+      {
+        "template": "Él ______ (dar) clases de matemáticas en la universidad.",
+        "answer": "da"
+      },
+      {
+        "template": "Nosotros ______ (dar) un paseo por el parque cada tarde.",
+        "answer": "damos"
+      },
+      {
+        "template": "Vosotros ______ (dar) de comer a los patos en el estanque.",
+        "answer": "dais"
+      },
+      {
+        "template": "Ellos ______ (dar) una fiesta este fin de semana.",
+        "answer": "dan"
+      }
+    ],
+    "preterito_indefinido": [
+      {
+        "template": "Ayer yo le ______ (dar) una sorpresa a mi hermano.",
+        "answer": "di"
+      },
+      {
+        "template": "¿Qué le ______ (dar) tú a tu madre por su cumpleaños?",
+        "answer": "diste"
+      },
+      {
+        "template": "Él ______ (dar) un discurso muy emotivo en la ceremonia.",
+        "answer": "dio"
+      },
+      {
+        "template": "Nosotros ______ (dar) un paseo por la ciudad anoche.",
+        "answer": "dimos"
+      },
+      {
+        "template": "Vosotros le ______ (dar) una oportunidad, pero no la aprovechó.",
+        "answer": "disteis"
+      },
+      {
+        "template": "Ellos ______ (dar) las gracias por la ayuda recibida.",
+        "answer": "dieron"
+      }
+    ],
+    "preterito_perfecto_compuesto": [
+      {
+        "template": "Yo le ______ (dar) el libro esta mañana.",
+        "answer": "he dado"
+      },
+      {
+        "template": "¿Tú le ______ (dar) la noticia a María?",
+        "answer": "has dado"
+      },
+      {
+        "template": "Él siempre nos ______ (dar) buenos ejemplos.",
+        "answer": "ha dado"
+      },
+      {
+        "template": "Nosotros ______ (dar) nuestro mejor esfuerzo en el proyecto.",
+        "answer": "hemos dado"
+      },
+      {
+        "template": "Vosotros ______ (dar) un gran espectáculo en la función.",
+        "answer": "habéis dado"
+      },
+      {
+        "template": "Ellos ______ (dar) muchas oportunidades a los empleados nuevos.",
+        "answer": "han dado"
+      }
+    ],
+    "subjuntivo_imperfecto_ra": [
+      {
+        "template": "Si yo te ______ (dar) mi opinión, ¿te enfadarías?",
+        "answer": "diera"
+      },
+      {
+        "template": "Si tú me ______ (dar) más tiempo, lo terminaría.",
+        "answer": "dieras"
+      },
+      {
+        "template": "Si él nos ______ (dar) permiso, iríamos a la fiesta.",
+        "answer": "diera"
+      },
+      {
+        "template": "Si nosotros le ______ (dar) una oportunidad, podría sorprendernos.",
+        "answer": "diéramos"
+      },
+      {
+        "template": "Si vosotros ______ (dar) un paso al frente, cambiaríais la situación.",
+        "answer": "dierais"
+      },
+      {
+        "template": "Si ellos ______ (dar) su brazo a torcer, el acuerdo sería posible.",
+        "answer": "dieran"
+      }
+    ],
+    "subjuntivo_presente": [
+      {
+        "template": "Espero que yo le ______ (dar) una buena impresión al entrevistador.",
+        "answer": "dé"
+      },
+      {
+        "template": "Es importante que tú ______ (dar) las gracias por el regalo.",
+        "answer": "des"
+      },
+      {
+        "template": "Es posible que él nos ______ (dar) una explicación convincente.",
+        "answer": "dé"
+      },
+      {
+        "template": "Es necesario que nosotros ______ (dar) nuestro consentimiento para el procedimiento.",
+        "answer": "demos"
+      },
+      {
+        "template": "Dudo que vosotros le ______ (dar) tanta importancia a ese asunto.",
+        "answer": "deis"
+      },
+      {
+        "template": "Es probable que ellos nos ______ (dar) una cálida bienvenida.",
+        "answer": "den"
+      }
+    ]
+  },
+  "decir": {
+    "condicional": [
+      {
+        "template": "Si supiera la respuesta, yo te la ______ (decir).",
+        "answer": "diría"
+      },
+      {
+        "template": "¿Qué ______ (decir) tú en mi lugar?",
+        "answer": "dirías"
+      },
+      {
+        "template": "Él ______ (decir) cualquier cosa para salvarse.",
+        "answer": "diría"
+      },
+      {
+        "template": "Nosotros ______ (decir) que sí, si nos invitaran.",
+        "answer": "diríamos"
+      },
+      {
+        "template": "Vosotros ______ (decir) la verdad, ¿no es cierto?",
+        "answer": "diríais"
+      },
+      {
+        "template": "Ellos ______ (decir) que están ocupados para no venir.",
+        "answer": "dirían"
+      }
+    ],
+    "futuro": [
+      {
+        "template": "Mañana yo te ______ (decir) lo que decida.",
+        "answer": "diré"
+      },
+      {
+        "template": "¿Qué ______ (decir) tú cuando lo veas?",
+        "answer": "dirás"
+      },
+      {
+        "template": "Él ______ (decir) la verdad tarde o temprano.",
+        "answer": "dirá"
+      },
+      {
+        "template": "Nosotros ______ (decir) nuestro discurso en la conferencia.",
+        "answer": "diremos"
+      },
+      {
+        "template": "Vosotros ______ (decir) lo que habéis aprendido en el curso.",
+        "answer": "diréis"
+      },
+      {
+        "template": "Ellos ______ (decir) si están de acuerdo con el plan.",
+        "answer": "dirán"
+      }
+    ],
+    "imperativo_afirmativo": [
+      {
+        "template": "(Tú) ¡______ (decir) la verdad ahora mismo!",
+        "answer": "di"
+      },
+      {
+        "template": "(Usted) ______ (decir) su nombre completo, por favor.",
+        "answer": "diga"
+      },
+      {
+        "template": "(Nosotros) ______ (decir) qué pensamos sobre este asunto.",
+        "answer": "digamos"
+      },
+      {
+        "template": "(Vosotros) ¡______ (decir) lo que sabéis sin miedo!",
+        "answer": "decid"
+      },
+      {
+        "template": "(Ustedes) ______ (decir) si están de acuerdo o no.",
+        "answer": "digan"
+      }
+    ],
+    "imperfecto": [
+      {
+        "template": "Cuando era pequeño, yo siempre ______ (decir) la verdad a mis padres.",
+        "answer": "decía"
+      },
+      {
+        "template": "Tú ______ (decir) que querías ser astronauta.",
+        "answer": "decías"
+      },
+      {
+        "template": "Él ______ (decir) chistes muy buenos en las fiestas.",
+        "answer": "decía"
+      },
+      {
+        "template": "Nosotros ______ (decir) que íbamos a ganar el campeonato.",
+        "answer": "decíamos"
+      },
+      {
+        "template": "Vosotros siempre ______ (decir) que estudiaríais más.",
+        "answer": "decíais"
+      },
+      {
+        "template": "Ellos ______ (decir) que el viaje era demasiado largo.",
+        "answer": "decían"
+      }
+    ],
+    "pluscuamperfecto": [
+      {
+        "template": "Yo ya te ______ (decir) que no quería ir antes de que insistieras.",
+        "answer": "había dicho"
+      },
+      {
+        "template": "Tú me ______ (decir) que habías terminado el proyecto, pero no era verdad.",
+        "answer": "habías dicho"
+      },
+      {
+        "template": "Él ______ (decir) que llegaría temprano, pero se retrasó.",
+        "answer": "había dicho"
+      },
+      {
+        "template": "Nosotros ______ (decir) que no estábamos de acuerdo con la propuesta inicial.",
+        "answer": "habíamos dicho"
+      },
+      {
+        "template": "Vosotros ______ (decir) que lo haríais, pero no cumplisteis.",
+        "answer": "habíais dicho"
+      },
+      {
+        "template": "Ellos ______ (decir) que el examen había sido fácil, pero suspendieron.",
+        "answer": "habían dicho"
+      }
+    ],
+    "presente": [
+      {
+        "template": "Yo siempre ______ (decir) la verdad.",
+        "answer": "digo"
+      },
+      {
+        "template": "Tú ______ (decir) cosas muy interesantes.",
+        "answer": "dices"
+      },
+      {
+        "template": "Él ______ (decir) que vendrá mañana.",
+        "answer": "dice"
+      },
+      {
+        "template": "Nosotros ______ (decir) lo que pensamos.",
+        "answer": "decimos"
+      },
+      {
+        "template": "Vosotros ______ (decir) que es fácil, pero no lo es.",
+        "answer": "decís"
+      },
+      {
+        "template": "Ellos ______ (decir) que están de acuerdo.",
+        "answer": "dicen"
+      }
+    ],
+    "preterito_indefinido": [
+      {
+        "template": "Ayer yo te ______ (decir) que no vinieras.",
+        "answer": "dije"
+      },
+      {
+        "template": "¿Qué ______ (decir) tú cuando te enteraste de la noticia?",
+        "answer": "dijiste"
+      },
+      {
+        "template": "Él ______ (decir) que no sabía nada al respecto.",
+        "answer": "dijo"
+      },
+      {
+        "template": "Nosotros ______ (decir) la verdad durante el interrogatorio.",
+        "answer": "dijimos"
+      },
+      {
+        "template": "Vosotros ______ (decir) que estabais cansados, por eso no fuisteis.",
+        "answer": "dijisteis"
+      },
+      {
+        "template": "Ellos ______ (decir) que llegarían tarde a la cena.",
+        "answer": "dijeron"
+      }
+    ],
+    "preterito_perfecto_compuesto": [
+      {
+        "template": "Hoy yo ______ (decir) toda la verdad en la reunión.",
+        "answer": "he dicho"
+      },
+      {
+        "template": "Esta semana tú ______ (decir) muchas cosas importantes.",
+        "answer": "has dicho"
+      },
+      {
+        "template": "Él siempre ______ (decir) lo que piensa sin filtros.",
+        "answer": "ha dicho"
+      },
+      {
+        "template": "Nosotros ______ (decir) que apoyaríamos la causa.",
+        "answer": "hemos dicho"
+      },
+      {
+        "template": "Vosotros ______ (decir) que vendríais, ¿qué pasó?",
+        "answer": "habéis dicho"
+      },
+      {
+        "template": "Ellos ______ (decir) que no están interesados en la oferta.",
+        "answer": "han dicho"
+      }
+    ],
+    "subjuntivo_imperfecto_ra": [
+      {
+        "template": "Si yo ______ (decir) lo que pienso, se enfadarían.",
+        "answer": "dijera"
+      },
+      {
+        "template": "Si tú ______ (decir) la verdad, te creerían.",
+        "answer": "dijeras"
+      },
+      {
+        "template": "Si él ______ (decir) que viene, lo esperaríamos.",
+        "answer": "dijera"
+      },
+      {
+        "template": "Si nosotros ______ (decir) que no, ¿qué pasaría?",
+        "answer": "dijéramos"
+      },
+      {
+        "template": "Si vosotros ______ (decir) que estáis ocupados, lo entenderían.",
+        "answer": "dijerais"
+      },
+      {
+        "template": "Si ellos ______ (decir) que necesitan ayuda, los apoyaríamos.",
+        "answer": "dijeran"
+      }
+    ],
+    "subjuntivo_presente": [
+      {
+        "template": "Espero que yo no ______ (decir) ninguna tontería.",
+        "answer": "diga"
+      },
+      {
+        "template": "Es importante que tú ______ (decir) lo que sientes.",
+        "answer": "digas"
+      },
+      {
+        "template": "Es posible que él ______ (decir) que no puede venir.",
+        "answer": "diga"
+      },
+      {
+        "template": "Es necesario que nosotros ______ (decir) la verdad sobre lo ocurrido.",
+        "answer": "digamos"
+      },
+      {
+        "template": "Dudo que vosotros ______ (decir) siempre lo que pensáis.",
+        "answer": "digáis"
+      },
+      {
+        "template": "Es probable que ellos ______ (decir) que necesitan más tiempo.",
+        "answer": "digan"
+      }
+    ]
+  },
+  "estar": {
+    "condicional": [
+      {
+        "template": "Si tuviera tiempo, yo ______ (estar) en el parque ahora mismo.",
+        "answer": "estaría"
+      },
+      {
+        "template": "Tú ______ (estar) más relajado si durmieras más.",
+        "answer": "estarías"
+      },
+      {
+        "template": "Él ______ (estar) muy agradecido si lo ayudaras.",
+        "answer": "estaría"
+      },
+      {
+        "template": "Nosotros ______ (estar) encantados de acompañarte, si pudiéramos.",
+        "answer": "estaríamos"
+      },
+      {
+        "template": "Vosotros ______ (estar) mejor si os abrigarais.",
+        "answer": "estaríais"
+      },
+      {
+        "template": "Ellos ______ (estar) más contentos si ganaran el partido.",
+        "answer": "estarían"
+      }
+    ],
+    "futuro": [
+      {
+        "template": "Mañana yo ______ (estar) en casa todo el día.",
+        "answer": "estaré"
+      },
+      {
+        "template": "La próxima semana tú ______ (estar) de viaje.",
+        "answer": "estarás"
+      },
+      {
+        "template": "Él ______ (estar) disponible para la reunión de mañana.",
+        "answer": "estará"
+      },
+      {
+        "template": "Nosotros ______ (estar) más tranquilos cuando termine el examen.",
+        "answer": "estaremos"
+      },
+      {
+        "template": "Vosotros ______ (estar) muy ocupados con los preparativos.",
+        "answer": "estaréis"
+      },
+      {
+        "template": "Ellos ______ (estar) esperándonos en la entrada.",
+        "answer": "estarán"
+      }
+    ],
+    "imperativo_afirmativo": [
+      {
+        "template": "(Tú) ¡______ (estar) quieto un momento!",
+        "answer": "está"
+      },
+      {
+        "template": "(Usted) ______ (estar) preparado para la presentación.",
+        "answer": "esté"
+      },
+      {
+        "template": "(Nosotros) ______ (estar) atentos a las instrucciones.",
+        "answer": "estemos"
+      },
+      {
+        "template": "(Vosotros) ¡______ (estar) listos para salir en cinco minutos!",
+        "answer": "estad"
+      },
+      {
+        "template": "(Ustedes) ______ (estar) tranquilos, todo está bajo control.",
+        "answer": "estén"
+      }
+    ],
+    "imperfecto": [
+      {
+        "template": "Cuando era joven, yo ______ (estar) siempre jugando afuera.",
+        "answer": "estaba"
+      },
+      {
+        "template": "Antes, tú ______ (estar) más tiempo en casa.",
+        "answer": "estabas"
+      },
+      {
+        "template": "Él ______ (estar) muy enfermo la semana pasada.",
+        "answer": "estaba"
+      },
+      {
+        "template": "Nosotros ______ (estar) de vacaciones cuando llamaste.",
+        "answer": "estábamos"
+      },
+      {
+        "template": "Vosotros ______ (estar) en el parque todos los días.",
+        "answer": "estabais"
+      },
+      {
+        "template": "Ellos ______ (estar) muy contentos en la fiesta de anoche.",
+        "answer": "estaban"
+      }
+    ],
+    "pluscuamperfecto": [
+      {
+        "template": "Cuando llegué, yo ya ______ (estar) listo por horas.",
+        "answer": "había estado"
+      },
+      {
+        "template": "Antes de la llamada, tú ______ (estar) durmiendo.",
+        "answer": "habías estado"
+      },
+      {
+        "template": "Él ______ (estar) en esa posición antes de la promoción.",
+        "answer": "había estado"
+      },
+      {
+        "template": "Nosotros ______ (estar) allí muchas veces antes de la última visita.",
+        "answer": "habíamos estado"
+      },
+      {
+        "template": "Vosotros ya ______ (estar) en el cine cuando os escribí.",
+        "answer": "habíais estado"
+      },
+      {
+        "template": "Ellos ______ (estar) preocupados hasta que recibieron la noticia.",
+        "answer": "habían estado"
+      }
+    ],
+    "presente": [
+      {
+        "template": "Yo ______ (estar) en la biblioteca.",
+        "answer": "estoy"
+      },
+      {
+        "template": "Tú ______ (estar) muy cansado hoy.",
+        "answer": "estás"
+      },
+      {
+        "template": "Ella ______ (estar) contenta con su nuevo trabajo.",
+        "answer": "está"
+      },
+      {
+        "template": "Nosotros ______ (estar) esperando el autobús.",
+        "answer": "estamos"
+      },
+      {
+        "template": "Vosotros ______ (estar) de vacaciones en la playa.",
+        "answer": "estáis"
+      },
+      {
+        "template": "Ustedes ______ (estar) en el lugar correcto.",
+        "answer": "están"
+      }
+    ],
+    "preterito_indefinido": [
+      {
+        "template": "Ayer yo ______ (estar) en el supermercado.",
+        "answer": "estuve"
+      },
+      {
+        "template": "La semana pasada tú ______ (estar) de viaje de negocios.",
+        "answer": "estuviste"
+      },
+      {
+        "template": "Él ______ (estar) ausente en la reunión de ayer.",
+        "answer": "estuvo"
+      },
+      {
+        "template": "Nosotros ______ (estar) juntos en el concierto.",
+        "answer": "estuvimos"
+      },
+      {
+        "template": "Vosotros ______ (estar) en la fiesta hasta tarde.",
+        "answer": "estuvisteis"
+      },
+      {
+        "template": "Ellos ______ (estar) muy callados durante la cena.",
+        "answer": "estuvieron"
+      }
+    ],
+    "preterito_perfecto_compuesto": [
+      {
+        "template": "Esta mañana yo ______ (estar) en el médico.",
+        "answer": "he estado"
+      },
+      {
+        "template": "Hoy tú ______ (estar) muy ocupado en la oficina.",
+        "answer": "has estado"
+      },
+      {
+        "template": "Ella ______ (estar) de viaje toda la semana.",
+        "answer": "ha estado"
+      },
+      {
+        "template": "Nosotros ______ (estar) trabajando en este proyecto por meses.",
+        "answer": "hemos estado"
+      },
+      {
+        "template": "Vosotros ______ (estar) esperando noticias desde ayer.",
+        "answer": "habéis estado"
+      },
+      {
+        "template": "Ellos ______ (estar) en silencio durante toda la reunión.",
+        "answer": "han estado"
+      }
+    ],
+    "subjuntivo_imperfecto_ra": [
+      {
+        "template": "Si yo ______ (estar) más cerca, te visitaría.",
+        "answer": "estuviera"
+      },
+      {
+        "template": "Si tú ______ (estar) aquí, todo sería diferente.",
+        "answer": "estuvieras"
+      },
+      {
+        "template": "Si él ______ (estar) en casa, podríamos hablar.",
+        "answer": "estuviera"
+      },
+      {
+        "template": "Si nosotros ______ (estar) de acuerdo, empezaríamos el proyecto.",
+        "answer": "estuviéramos"
+      },
+      {
+        "template": "Si vosotros ______ (estar) menos ocupados, vendríais a la fiesta.",
+        "answer": "estuvierais"
+      },
+      {
+        "template": "Si ellos ______ (estar) más atentos, entenderían el problema.",
+        "answer": "estuvieran"
+      }
+    ],
+    "subjuntivo_presente": [
+      {
+        "template": "Espero que yo ______ (estar) a tiempo para la reunión.",
+        "answer": "esté"
+      },
+      {
+        "template": "Es necesario que tú ______ (estar) tranquilo.",
+        "answer": "estés"
+      },
+      {
+        "template": "Es posible que ella ______ (estar) en la oficina.",
+        "answer": "esté"
+      },
+      {
+        "template": "Es importante que nosotros ______ (estar) preparados.",
+        "answer": "estemos"
+      },
+      {
+        "template": "Dudo que vosotros ______ (estar) listos para el examen.",
+        "answer": "estéis"
+      },
+      {
+        "template": "Es probable que ellos ______ (estar) de acuerdo con la propuesta.",
+        "answer": "estén"
+      }
+    ]
+  },
   "hablar": {
     "futuro": [
       {
@@ -111,30 +885,1865 @@ export const languageData: LanguageData = {
         "answer": "hablan"
       }
     ]
+  },
+  "hacer": {
+    "condicional": [
+      {
+        "template": "Si tuviera los ingredientes, yo ______ (hacer) un pastel.",
+        "answer": "haría"
+      },
+      {
+        "template": "Tú ______ (hacer) lo mismo en mi situación, ¿verdad?",
+        "answer": "harías"
+      },
+      {
+        "template": "Él ______ (hacer) cualquier cosa por sus amigos.",
+        "answer": "haría"
+      },
+      {
+        "template": "Nosotros ______ (hacer) la tarea juntos si estuviéramos en la misma clase.",
+        "answer": "haríamos"
+      },
+      {
+        "template": "Vosotros ______ (hacer) bien en revisar el documento antes de enviarlo.",
+        "answer": "haríais"
+      },
+      {
+        "template": "Ellas ______ (hacer) un viaje alrededor del mundo si tuvieran dinero.",
+        "answer": "harían"
+      }
+    ],
+    "futuro": [
+      {
+        "template": "Mañana yo ______ (hacer) la compra semanal.",
+        "answer": "haré"
+      },
+      {
+        "template": "El próximo mes tú ______ (hacer) un curso de fotografía.",
+        "answer": "harás"
+      },
+      {
+        "template": "Él ______ (hacer) todo lo posible para ayudarte.",
+        "answer": "hará"
+      },
+      {
+        "template": "Nosotros ______ (hacer) una fiesta si ganamos el partido.",
+        "answer": "haremos"
+      },
+      {
+        "template": "Vosotros ______ (hacer) el examen final la próxima semana.",
+        "answer": "haréis"
+      },
+      {
+        "template": "Ellas ______ (hacer) una presentación sobre el cambio climático.",
+        "answer": "harán"
+      }
+    ],
+    "imperativo_afirmativo": [
+      {
+        "template": "(Tú) ¡______ (hacer) tu cama ahora mismo!",
+        "answer": "haz"
+      },
+      {
+        "template": "(Usted) ______ (hacer) el favor de esperar un momento.",
+        "answer": "haga"
+      },
+      {
+        "template": "(Nosotros) ______ (hacer) un brindis por los novios.",
+        "answer": "hagamos"
+      },
+      {
+        "template": "(Vosotros) ¡______ (hacer) los deberes antes de salir a jugar!",
+        "answer": "haced"
+      },
+      {
+        "template": "(Ustedes) ______ (hacer) silencio en la biblioteca.",
+        "answer": "hagan"
+      }
+    ],
+    "imperfecto": [
+      {
+        "template": "De niño, yo siempre ______ (hacer) mis deberes después de merendar.",
+        "answer": "hacía"
+      },
+      {
+        "template": "Tú ______ (hacer) mucho deporte cuando vivías en la costa.",
+        "answer": "hacías"
+      },
+      {
+        "template": "Él ______ (hacer) maquetas de aviones en su tiempo libre.",
+        "answer": "hacía"
+      },
+      {
+        "template": "Nosotros ______ (hacer) senderismo los fines de semana.",
+        "answer": "hacíamos"
+      },
+      {
+        "template": "Vosotros ______ (hacer) tartas deliciosas para los cumpleaños.",
+        "answer": "hacíais"
+      },
+      {
+        "template": "Ellas ______ (hacer) yoga en el parque cada mañana.",
+        "answer": "hacían"
+      }
+    ],
+    "pluscuamperfecto": [
+      {
+        "template": "Yo ya ______ (hacer) la compra cuando me llamaste.",
+        "answer": "había hecho"
+      },
+      {
+        "template": "Tú ______ (hacer) el ridículo antes de darte cuenta.",
+        "answer": "habías hecho"
+      },
+      {
+        "template": "Él ______ (hacer) un gran descubrimiento antes de publicarlo.",
+        "answer": "había hecho"
+      },
+      {
+        "template": "Nosotros ______ (hacer) todo lo posible antes de rendirnos.",
+        "answer": "habíamos hecho"
+      },
+      {
+        "template": "Vosotros ______ (hacer) la reserva antes de llegar al hotel.",
+        "answer": "habíais hecho"
+      },
+      {
+        "template": "Ellas ______ (hacer) el trabajo antes de la fecha límite.",
+        "answer": "habían hecho"
+      }
+    ],
+    "presente": [
+      {
+        "template": "Yo ______ (hacer) mi tarea por la tarde.",
+        "answer": "hago"
+      },
+      {
+        "template": "Tú ______ (hacer) mucho ruido cuando cocinas.",
+        "answer": "haces"
+      },
+      {
+        "template": "Él ______ (hacer) ejercicio todas las mañanas.",
+        "answer": "hace"
+      },
+      {
+        "template": "Nosotros ______ (hacer) planes para el fin de semana.",
+        "answer": "hacemos"
+      },
+      {
+        "template": "Vosotros ______ (hacer) un gran trabajo en equipo.",
+        "answer": "hacéis"
+      },
+      {
+        "template": "Ellas ______ (hacer) pasteles deliciosos.",
+        "answer": "hacen"
+      }
+    ],
+    "preterito_indefinido": [
+      {
+        "template": "Ayer yo ______ (hacer) la cena para mi familia.",
+        "answer": "hice"
+      },
+      {
+        "template": "La semana pasada tú ______ (hacer) un viaje a la montaña.",
+        "answer": "hiciste"
+      },
+      {
+        "template": "Él ______ (hacer) un pastel de chocolate el sábado.",
+        "answer": "hizo"
+      },
+      {
+        "template": "Nosotros ______ (hacer) una fogata en la playa anoche.",
+        "answer": "hicimos"
+      },
+      {
+        "template": "Vosotros ______ (hacer) un buen trabajo con la presentación.",
+        "answer": "hicisteis"
+      },
+      {
+        "template": "Ellas ______ (hacer) sus maletas justo antes de salir.",
+        "answer": "hicieron"
+      }
+    ],
+    "preterito_perfecto_compuesto": [
+      {
+        "template": "Hoy yo ______ (hacer) todo lo que estaba en mi lista.",
+        "answer": "he hecho"
+      },
+      {
+        "template": "Esta semana tú ______ (hacer) un gran esfuerzo.",
+        "answer": "has hecho"
+      },
+      {
+        "template": "Él ______ (hacer) la cena para nosotros esta noche.",
+        "answer": "ha hecho"
+      },
+      {
+        "template": "Nosotros ______ (hacer) progresos significativos en el proyecto.",
+        "answer": "hemos hecho"
+      },
+      {
+        "template": "Vosotros ______ (hacer) muchas preguntas interesantes hoy.",
+        "answer": "habéis hecho"
+      },
+      {
+        "template": "Ellas ______ (hacer) un descubrimiento importante.",
+        "answer": "han hecho"
+      }
+    ],
+    "subjuntivo_imperfecto_ra": [
+      {
+        "template": "Si yo ______ (hacer) más ejercicio, estaría en forma.",
+        "answer": "hiciera"
+      },
+      {
+        "template": "Si tú ______ (hacer) tu cama cada mañana, tu cuarto se vería mejor.",
+        "answer": "hicieras"
+      },
+      {
+        "template": "Si él ______ (hacer) menos ruido, los vecinos no se quejarían.",
+        "answer": "hiciera"
+      },
+      {
+        "template": "Si nosotros ______ (hacer) un esfuerzo, podríamos terminar a tiempo.",
+        "answer": "hiciéramos"
+      },
+      {
+        "template": "Si vosotros ______ (hacer) caso a las instrucciones, no tendríais problemas.",
+        "answer": "hicierais"
+      },
+      {
+        "template": "Si ellas ______ (hacer) la tarea, obtendrían mejores notas.",
+        "answer": "hicieran"
+      }
+    ],
+    "subjuntivo_presente": [
+      {
+        "template": "Espero que yo ______ (hacer) un buen trabajo.",
+        "answer": "haga"
+      },
+      {
+        "template": "Es importante que tú ______ (hacer) ejercicio regularmente.",
+        "answer": "hagas"
+      },
+      {
+        "template": "Es posible que ella ______ (hacer) la tarta para la fiesta.",
+        "answer": "haga"
+      },
+      {
+        "template": "Es necesario que nosotros ______ (hacer) algo para ayudar.",
+        "answer": "hagamos"
+      },
+      {
+        "template": "Dudo que vosotros ______ (hacer) todo el trabajo a tiempo.",
+        "answer": "hagáis"
+      },
+      {
+        "template": "Es probable que ellas ______ (hacer) lo correcto.",
+        "answer": "hagan"
+      }
+    ]
+  },
+  "ir": {
+    "condicional": [
+      {
+        "template": "Si tuviera tiempo, yo ______ (ir) al cine más a menudo.",
+        "answer": "iría"
+      },
+      {
+        "template": "¿Tú ______ (ir) a la fiesta si te invitaran?",
+        "answer": "irías"
+      },
+      {
+        "template": "Él ______ (ir) con nosotros si no tuviera que trabajar.",
+        "answer": "iría"
+      },
+      {
+        "template": "Nosotros ______ (ir) a la playa si hiciera mejor tiempo.",
+        "answer": "iríamos"
+      },
+      {
+        "template": "Vosotros ______ (ir) de viaje si ganarais la lotería.",
+        "answer": "iríais"
+      },
+      {
+        "template": "Ellos ______ (ir) al concierto si tuvieran entradas.",
+        "answer": "irían"
+      }
+    ],
+    "futuro": [
+      {
+        "template": "Mañana yo ______ (ir) a la playa si hace buen tiempo.",
+        "answer": "iré"
+      },
+      {
+        "template": "¿Cuándo ______ (ir) tú a visitar a tus abuelos?",
+        "answer": "irás"
+      },
+      {
+        "template": "Él ______ (ir) al médico la próxima semana.",
+        "answer": "irá"
+      },
+      {
+        "template": "Nosotros ______ (ir) de compras este fin de semana.",
+        "answer": "iremos"
+      },
+      {
+        "template": "Vosotros ______ (ir) a la fiesta de cumpleaños de María, ¿verdad?",
+        "answer": "iréis"
+      },
+      {
+        "template": "Ellos ______ (ir) de viaje a Europa el próximo mes.",
+        "answer": "irán"
+      }
+    ],
+    "imperativo_afirmativo": [
+      {
+        "template": "(Tú) ¡______ (ir) a tu habitación ahora mismo!",
+        "answer": "ve"
+      },
+      {
+        "template": "(Usted) ______ (ir) con cuidado por la calle.",
+        "answer": "vaya"
+      },
+      {
+        "template": "(Nosotros) ______ (ir) al parque a jugar.",
+        "answer": "vamos"
+      },
+      {
+        "template": "(Vosotros) ¡______ (ir) a casa, ya es tarde!",
+        "answer": "id"
+      },
+      {
+        "template": "(Ustedes) ______ (ir) a la recepción para registrarse.",
+        "answer": "vayan"
+      }
+    ],
+    "imperfecto": [
+      {
+        "template": "Cuando era niño, yo ______ (ir) al parque todos los días.",
+        "answer": "iba"
+      },
+      {
+        "template": "Tú ______ (ir) a la casa de tu abuela los domingos.",
+        "answer": "ibas"
+      },
+      {
+        "template": "Él ______ (ir) a clases de piano los martes.",
+        "answer": "iba"
+      },
+      {
+        "template": "Nosotros ______ (ir) juntos a la escuela primaria.",
+        "answer": "íbamos"
+      },
+      {
+        "template": "Vosotros ______ (ir) de campamento en verano.",
+        "answer": "ibais"
+      },
+      {
+        "template": "Ellos ______ (ir) al cine con frecuencia.",
+        "answer": "iban"
+      }
+    ],
+    "pluscuamperfecto": [
+      {
+        "template": "Yo ya ______ (ir) al supermercado cuando me llamaste.",
+        "answer": "había ido"
+      },
+      {
+        "template": "Tú ______ (ir) al banco antes de que cerrara, ¿verdad?",
+        "answer": "habías ido"
+      },
+      {
+        "template": "Él ______ (ir) a la oficina temprano ese día.",
+        "answer": "había ido"
+      },
+      {
+        "template": "Nosotros ______ (ir) a ese restaurante antes, pero no nos gustó.",
+        "answer": "habíamos ido"
+      },
+      {
+        "template": "Vosotros ya ______ (ir) de vacaciones cuando os avisaron del problema.",
+        "answer": "habíais ido"
+      },
+      {
+        "template": "Ellos ______ (ir) al aeropuerto con mucho tiempo de antelación.",
+        "answer": "habían ido"
+      }
+    ],
+    "presente": [
+      {
+        "template": "Yo ______ (ir) al mercado todos los sábados.",
+        "answer": "voy"
+      },
+      {
+        "template": "Tú ______ (ir) a la escuela en autobús.",
+        "answer": "vas"
+      },
+      {
+        "template": "Ella ______ (ir) al gimnasio por las tardes.",
+        "answer": "va"
+      },
+      {
+        "template": "Nosotros ______ (ir) de vacaciones a la playa en verano.",
+        "answer": "vamos"
+      },
+      {
+        "template": "Vosotros ______ (ir) al cine esta noche.",
+        "answer": "vais"
+      },
+      {
+        "template": "Ustedes ______ (ir) a la reunión de padres.",
+        "answer": "van"
+      }
+    ],
+    "preterito_indefinido": [
+      {
+        "template": "Ayer yo ______ (ir) al cine con mis amigos.",
+        "answer": "fui"
+      },
+      {
+        "template": "¿Adónde ______ (ir) tú de vacaciones el año pasado?",
+        "answer": "fuiste"
+      },
+      {
+        "template": "Él ______ (ir) a la biblioteca a estudiar.",
+        "answer": "fue"
+      },
+      {
+        "template": "Nosotros ______ (ir) a la montaña el fin de semana pasado.",
+        "answer": "fuimos"
+      },
+      {
+        "template": "Vosotros ______ (ir) al concierto de rock anoche.",
+        "answer": "fuisteis"
+      },
+      {
+        "template": "Ellos ______ (ir) de excursión al campo.",
+        "answer": "fueron"
+      }
+    ],
+    "preterito_perfecto_compuesto": [
+      {
+        "template": "Este año yo ______ (ir) a tres bodas.",
+        "answer": "he ido"
+      },
+      {
+        "template": "¿Alguna vez tú ______ (ir) a Asia?",
+        "answer": "has ido"
+      },
+      {
+        "template": "Ella ______ (ir) a la tienda a comprar pan.",
+        "answer": "ha ido"
+      },
+      {
+        "template": "Nosotros ______ (ir) muchas veces a ese restaurante.",
+        "answer": "hemos ido"
+      },
+      {
+        "template": "Vosotros nunca ______ (ir) al museo de cera.",
+        "answer": "habéis ido"
+      },
+      {
+        "template": "Ellos ______ (ir) al extranjero por trabajo.",
+        "answer": "han ido"
+      }
+    ],
+    "subjuntivo_imperfecto_ra": [
+      {
+        "template": "Si yo ______ (ir) a la fiesta, te habría visto.",
+        "answer": "fuera"
+      },
+      {
+        "template": "Si tú ______ (ir) más despacio, no te habrías caído.",
+        "answer": "fueras"
+      },
+      {
+        "template": "Si él ______ (ir) al médico antes, no estaría tan enfermo.",
+        "answer": "fuera"
+      },
+      {
+        "template": "Si nosotros ______ (ir) de vacaciones juntos, nos divertiríamos mucho.",
+        "answer": "fuéramos"
+      },
+      {
+        "template": "Si vosotros ______ (ir) al concierto, necesitaríais comprar entradas.",
+        "answer": "fuerais"
+      },
+      {
+        "template": "Si ellos ______ (ir) a la reunión, podrían dar su opinión.",
+        "answer": "fueran"
+      }
+    ],
+    "subjuntivo_presente": [
+      {
+        "template": "Espero que yo ______ (ir) a la fiesta esta noche.",
+        "answer": "vaya"
+      },
+      {
+        "template": "Es importante que tú ______ (ir) al médico para un chequeo.",
+        "answer": "vayas"
+      },
+      {
+        "template": "Es posible que él ______ (ir) de vacaciones a Italia.",
+        "answer": "vaya"
+      },
+      {
+        "template": "Es necesario que nosotros ______ (ir) preparados para la reunión.",
+        "answer": "vayamos"
+      },
+      {
+        "template": "Dudo que vosotros ______ (ir) a terminar el proyecto a tiempo.",
+        "answer": "vayáis"
+      },
+      {
+        "template": "Es probable que ellos ______ (ir) al concierto si consiguen entradas.",
+        "answer": "vayan"
+      }
+    ]
+  },
+  "poder": {
+    "condicional": [
+      {
+        "template": "Si tuviera más dinero, yo ______ (poder) comprar un coche.",
+        "answer": "podría"
+      },
+      {
+        "template": "Tú ______ (poder) ayudarme si tuvieras tiempo, ¿verdad?",
+        "answer": "podrías"
+      },
+      {
+        "template": "Él ______ (poder) ser un gran atleta si entrenara más.",
+        "answer": "podría"
+      },
+      {
+        "template": "Nosotros ______ (poder) ir al concierto si consiguiéramos entradas.",
+        "answer": "podríamos"
+      },
+      {
+        "template": "Vosotros ______ (poder) aprender cualquier cosa si os lo propusierais.",
+        "answer": "podríais"
+      },
+      {
+        "template": "Ellos ______ (poder) viajar por el mundo si ganaran la lotería.",
+        "answer": "podrían"
+      }
+    ],
+    "futuro": [
+      {
+        "template": "Mañana yo ______ (poder) visitarte.",
+        "answer": "podré"
+      },
+      {
+        "template": "Con más práctica, tú ______ (poder) tocar el piano.",
+        "answer": "podrás"
+      },
+      {
+        "template": "Él ______ (poder) unirse a nosotros más tarde.",
+        "answer": "podrá"
+      },
+      {
+        "template": "Nosotros ______ (poder) ver la película el próximo fin de semana.",
+        "answer": "podremos"
+      },
+      {
+        "template": "Vosotros ______ (poder) alcanzar vuestros objetivos si os esforzáis.",
+        "answer": "podréis"
+      },
+      {
+        "template": "Ellos ______ (poder) resolver el problema si trabajan juntos.",
+        "answer": "podrán"
+      }
+    ],
+    "imperativo_afirmativo": [
+      {
+        "template": "(Tú) ¡______ (poder) hacerlo si te esfuerzas!",
+        "answer": "puede"
+      },
+      {
+        "template": "(Usted) ______ (poder) usted tomar la iniciativa en este asunto.",
+        "answer": "pueda"
+      },
+      {
+        "template": "(Nosotros) ______ (poder) nosotros encontrar una solución juntos.",
+        "answer": "podamos"
+      },
+      {
+        "template": "(Vosotros) ¡______ (poder) vosotros superar este desafío!",
+        "answer": "poded"
+      },
+      {
+        "template": "(Ustedes) ______ (poder) ustedes marcar la diferencia con su contribución.",
+        "answer": "puedan"
+      }
+    ],
+    "imperfecto": [
+      {
+        "template": "De niño, yo no ______ (poder) nadar muy bien.",
+        "answer": "podía"
+      },
+      {
+        "template": "Tú ______ (poder) correr más rápido cuando eras más joven.",
+        "answer": "podías"
+      },
+      {
+        "template": "Ella ______ (poder) cantar canciones muy bonitas.",
+        "answer": "podía"
+      },
+      {
+        "template": "Nosotros ______ (poder) jugar en el parque durante horas.",
+        "answer": "podíamos"
+      },
+      {
+        "template": "Vosotros ______ (poder) venir a visitarnos más a menudo.",
+        "answer": "podíais"
+      },
+      {
+        "template": "Ellos ______ (poder) ver el mar desde su antigua casa.",
+        "answer": "podían"
+      }
+    ],
+    "pluscuamperfecto": [
+      {
+        "template": "Yo ya ______ (poder) caminar largas distancias antes de la lesión.",
+        "answer": "había podido"
+      },
+      {
+        "template": "Tú ______ (poder) resolver el acertijo antes de que te dieran la pista.",
+        "answer": "habías podido"
+      },
+      {
+        "template": "Ella ______ (poder) terminar el maratón el año anterior.",
+        "answer": "había podido"
+      },
+      {
+        "template": "Nosotros ______ (poder) comprar la casa antes de que los precios subieran.",
+        "answer": "habíamos podido"
+      },
+      {
+        "template": "Vosotros ______ (poder) visitar el museo antes de que cerrara por reformas.",
+        "answer": "habíais podido"
+      },
+      {
+        "template": "Ellos ______ (poder) escapar antes de que llegara la tormenta.",
+        "answer": "habían podido"
+      }
+    ],
+    "presente": [
+      {
+        "template": "Yo ______ (poder) levantar objetos pesados.",
+        "answer": "puedo"
+      },
+      {
+        "template": "Tú ______ (poder) correr muy rápido.",
+        "answer": "puedes"
+      },
+      {
+        "template": "Ella ______ (poder) hablar tres idiomas.",
+        "answer": "puede"
+      },
+      {
+        "template": "Nosotros ______ (poder) ayudarte con la mudanza.",
+        "answer": "podemos"
+      },
+      {
+        "template": "Vosotros ______ (poder) resolver este problema.",
+        "answer": "podéis"
+      },
+      {
+        "template": "Ustedes ______ (poder) venir a la fiesta si quieren.",
+        "answer": "pueden"
+      }
+    ],
+    "preterito_indefinido": [
+      {
+        "template": "Ayer yo no ______ (poder) ir al cine.",
+        "answer": "pude"
+      },
+      {
+        "template": "Anoche tú ______ (poder) terminar el libro.",
+        "answer": "pudiste"
+      },
+      {
+        "template": "Él ______ (poder) levantar la caja pesada sin ayuda.",
+        "answer": "pudo"
+      },
+      {
+        "template": "Nosotros ______ (poder) llegar a tiempo a pesar del tráfico.",
+        "answer": "pudimos"
+      },
+      {
+        "template": "Vosotros ______ (poder) resolver el problema con ingenio.",
+        "answer": "pudisteis"
+      },
+      {
+        "template": "Ellos no ______ (poder) asistir a la reunión por un imprevisto.",
+        "answer": "pudieron"
+      }
+    ],
+    "preterito_perfecto_compuesto": [
+      {
+        "template": "Yo nunca ______ (poder) entender las matemáticas complejas.",
+        "answer": "he podido"
+      },
+      {
+        "template": "Tú ______ (poder) superar todos los obstáculos hasta ahora.",
+        "answer": "has podido"
+      },
+      {
+        "template": "Ella ______ (poder) terminar el proyecto a tiempo.",
+        "answer": "ha podido"
+      },
+      {
+        "template": "Nosotros ______ (poder) ahorrar suficiente dinero para el viaje.",
+        "answer": "hemos podido"
+      },
+      {
+        "template": "Vosotros ______ (poder) ver la película antes que nadie.",
+        "answer": "habéis podido"
+      },
+      {
+        "template": "Ellos ______ (poder) resolver el misterio gracias a las pistas.",
+        "answer": "han podido"
+      }
+    ],
+    "subjuntivo_imperfecto_ra": [
+      {
+        "template": "Si yo ______ (poder) volar, viajaría a la luna.",
+        "answer": "pudiera"
+      },
+      {
+        "template": "Si tú ______ (poder) leer mentes, ¿qué harías?",
+        "answer": "pudieras"
+      },
+      {
+        "template": "Si él ______ (poder) cambiar el pasado, lo haría.",
+        "answer": "pudiera"
+      },
+      {
+        "template": "Si nosotros ______ (poder) ayudar más, lo haríamos con gusto.",
+        "answer": "pudiéramos"
+      },
+      {
+        "template": "Si vosotros ______ (poder) elegir cualquier superpoder, ¿cuál sería?",
+        "answer": "pudierais"
+      },
+      {
+        "template": "Si ellos ______ (poder) venir antes, nos encontrarían aquí.",
+        "answer": "pudieran"
+      }
+    ],
+    "subjuntivo_presente": [
+      {
+        "template": "Espero que yo ______ (poder) ayudarte con tu proyecto.",
+        "answer": "pueda"
+      },
+      {
+        "template": "Es necesario que tú ______ (poder) concentrarte en tus estudios.",
+        "answer": "puedas"
+      },
+      {
+        "template": "Es posible que ella ______ (poder) venir a la fiesta mañana.",
+        "answer": "pueda"
+      },
+      {
+        "template": "Es importante que nosotros ______ (poder) encontrar una solución pronto.",
+        "answer": "podamos"
+      },
+      {
+        "template": "Dudo que vosotros ______ (poder) terminar el trabajo hoy mismo.",
+        "answer": "podáis"
+      },
+      {
+        "template": "Es probable que ellos ______ (poder) ganar el campeonato.",
+        "answer": "puedan"
+      }
+    ]
+  },
+  "saber": {
+    "condicional": [
+      {
+        "template": "Si estudiara más, yo ______ (saber) la respuesta.",
+        "answer": "sabría"
+      },
+      {
+        "template": "¿Tú ______ (saber) qué hacer en una emergencia como esa?",
+        "answer": "sabrías"
+      },
+      {
+        "template": "Él ______ (saber) la verdad si se la contaras.",
+        "answer": "sabría"
+      },
+      {
+        "template": "Nosotros ______ (saber) cómo ayudar si conociéramos el problema.",
+        "answer": "sabríamos"
+      },
+      {
+        "template": "Vosotros ______ (saber) la solución si pensarais un poco más.",
+        "answer": "sabríais"
+      },
+      {
+        "template": "Ellos ______ (saber) qué decir si estuvieran en nuestro lugar.",
+        "answer": "sabrían"
+      }
+    ],
+    "futuro": [
+      {
+        "template": "Mañana yo ______ (saber) los resultados del examen.",
+        "answer": "sabré"
+      },
+      {
+        "template": "¿Cuándo ______ (saber) tú la fecha del viaje?",
+        "answer": "sabrás"
+      },
+      {
+        "template": "Él ______ (saber) la respuesta cuando termine de investigar.",
+        "answer": "sabrá"
+      },
+      {
+        "template": "Nosotros ______ (saber) qué hacer después de la reunión.",
+        "answer": "sabremos"
+      },
+      {
+        "template": "Vosotros ______ (saber) la verdad en algún momento.",
+        "answer": "sabréis"
+      },
+      {
+        "template": "Ellos ______ (saber) cómo solucionar el problema.",
+        "answer": "sabrán"
+      }
+    ],
+    "imperativo_afirmativo": [
+      {
+        "template": "(Tú) ¡______ (saber) la lección para mañana!",
+        "answer": "sabe"
+      },
+      {
+        "template": "(Usted) ______ (saber) que esto es confidencial.",
+        "answer": "sepa"
+      },
+      {
+        "template": "(Nosotros) ______ (saber) cómo actuar en caso de emergencia.",
+        "answer": "sepamos"
+      },
+      {
+        "template": "(Vosotros) ¡______ (saber) las reglas antes de jugar!",
+        "answer": "sabed"
+      },
+      {
+        "template": "(Ustedes) ______ (saber) que estamos aquí para ayudarles.",
+        "answer": "sepan"
+      }
+    ],
+    "imperfecto": [
+      {
+        "template": "De niño, yo no ______ (saber) nadar.",
+        "answer": "sabía"
+      },
+      {
+        "template": "Tú ______ (saber) que eso iba a pasar, ¿verdad?",
+        "answer": "sabías"
+      },
+      {
+        "template": "Él ______ (saber) la lección de memoria.",
+        "answer": "sabía"
+      },
+      {
+        "template": "Nosotros ______ (saber) que teníamos que estudiar más.",
+        "answer": "sabíamos"
+      },
+      {
+        "template": "Vosotros ______ (saber) la respuesta, pero no la dijisteis.",
+        "answer": "sabíais"
+      },
+      {
+        "template": "Ellos ______ (saber) que el camino era peligroso.",
+        "answer": "sabían"
+      }
+    ],
+    "pluscuamperfecto": [
+      {
+        "template": "Yo ya ______ (saber) la respuesta antes de que la preguntaras.",
+        "answer": "había sabido"
+      },
+      {
+        "template": "Tú ______ (saber) que él vendría, ¿por qué te sorprendiste?",
+        "answer": "habías sabido"
+      },
+      {
+        "template": "Ella ______ (saber) desde el principio que no era una buena idea.",
+        "answer": "había sabido"
+      },
+      {
+        "template": "Nosotros ______ (saber) que tendríamos problemas con este proyecto.",
+        "answer": "habíamos sabido"
+      },
+      {
+        "template": "Vosotros ______ (saber) la combinación de la caja fuerte todo el tiempo.",
+        "answer": "habíais sabido"
+      },
+      {
+        "template": "Ellos ______ (saber) del riesgo, pero decidieron continuar.",
+        "answer": "habían sabido"
+      }
+    ],
+    "presente": [
+      {
+        "template": "Yo ______ (saber) la respuesta a esa pregunta.",
+        "answer": "sé"
+      },
+      {
+        "template": "Tú ______ (saber) hablar francés muy bien.",
+        "answer": "sabes"
+      },
+      {
+        "template": "Ella ______ (saber) cocinar paella.",
+        "answer": "sabe"
+      },
+      {
+        "template": "Nosotros ______ (saber) que tenemos un examen mañana.",
+        "answer": "sabemos"
+      },
+      {
+        "template": "Vosotros ______ (saber) dónde está la biblioteca, ¿verdad?",
+        "answer": "sabéis"
+      },
+      {
+        "template": "Ustedes ______ (saber) mucho sobre historia del arte.",
+        "answer": "saben"
+      }
+    ],
+    "preterito_indefinido": [
+      {
+        "template": "Ayer yo ______ (saber) la noticia por la radio.",
+        "answer": "supe"
+      },
+      {
+        "template": "¿Cuándo ______ (saber) tú que te ibas a mudar?",
+        "answer": "supiste"
+      },
+      {
+        "template": "Él ______ (saber) la verdad cuando leyó la carta.",
+        "answer": "supo"
+      },
+      {
+        "template": "Nosotros ______ (saber) del accidente por un amigo en común.",
+        "answer": "supimos"
+      },
+      {
+        "template": "Vosotros ______ (saber) que habíais aprobado el examen esta mañana.",
+        "answer": "supisteis"
+      },
+      {
+        "template": "Ellos ______ (saber) cómo reaccionar en esa situación de emergencia.",
+        "answer": "supieron"
+      }
+    ],
+    "preterito_perfecto_compuesto": [
+      {
+        "template": "Yo siempre ______ (saber) la verdad sobre ese asunto.",
+        "answer": "he sabido"
+      },
+      {
+        "template": "Tú ______ (saber) la respuesta todo este tiempo, ¿no?",
+        "answer": "has sabido"
+      },
+      {
+        "template": "Ella ______ (saber) cómo resolver el problema desde el principio.",
+        "answer": "ha sabido"
+      },
+      {
+        "template": "Nosotros ______ (saber) los resultados del examen esta mañana.",
+        "answer": "hemos sabido"
+      },
+      {
+        "template": "Vosotros ______ (saber) la noticia antes que nadie.",
+        "answer": "habéis sabido"
+      },
+      {
+        "template": "Ellos ______ (saber) de su llegada con antelación.",
+        "answer": "han sabido"
+      }
+    ],
+    "subjuntivo_imperfecto_ra": [
+      {
+        "template": "Si yo ______ (saber) la respuesta, te la diría.",
+        "answer": "supiera"
+      },
+      {
+        "template": "Si tú ______ (saber) la verdad, cambiarías de opinión.",
+        "answer": "supieras"
+      },
+      {
+        "template": "Si él ______ (saber) nadar, iría a la piscina.",
+        "answer": "supiera"
+      },
+      {
+        "template": "Si nosotros ______ (saber) dónde está, iríamos a buscarlo.",
+        "answer": "supiéramos"
+      },
+      {
+        "template": "Si vosotros ______ (saber) el secreto, ¿lo guardaríais?",
+        "answer": "supierais"
+      },
+      {
+        "template": "Si ellos ______ (saber) las consecuencias, no lo harían.",
+        "answer": "supieran"
+      }
+    ],
+    "subjuntivo_presente": [
+      {
+        "template": "Espero que yo ______ (saber) la respuesta correcta en el examen.",
+        "answer": "sepa"
+      },
+      {
+        "template": "Es importante que tú ______ (saber) la verdad sobre este asunto.",
+        "answer": "sepas"
+      },
+      {
+        "template": "Es posible que ella ______ (saber) dónde encontrarlo.",
+        "answer": "sepa"
+      },
+      {
+        "template": "Es necesario que nosotros ______ (saber) cómo funciona el sistema.",
+        "answer": "sepamos"
+      },
+      {
+        "template": "Dudo que vosotros ______ (saber) toda la historia completa.",
+        "answer": "sepáis"
+      },
+      {
+        "template": "Es probable que ellos ______ (saber) la noticia mañana.",
+        "answer": "sepan"
+      }
+    ]
+  },
+  "ser": {
+    "condicional": [
+      {
+        "template": "Si tuviera más dinero, yo ______ (ser) más generoso.",
+        "answer": "sería"
+      },
+      {
+        "template": "Tú ______ (ser) un excelente líder si te lo propusieras.",
+        "answer": "serías"
+      },
+      {
+        "template": "Él ______ (ser) más feliz si viviera cerca del mar.",
+        "answer": "sería"
+      },
+      {
+        "template": "Nosotros ______ (ser) los primeros en ayudar si nos necesitaran.",
+        "answer": "seríamos"
+      },
+      {
+        "template": "Con más práctica, vosotros ______ (ser) imparables.",
+        "answer": "seríais"
+      },
+      {
+        "template": "Ellos ______ (ser) más amigables si no estuvieran tan cansados.",
+        "answer": "serían"
+      }
+    ],
+    "futuro": [
+      {
+        "template": "Mañana yo ______ (ser) el primero en llegar.",
+        "answer": "seré"
+      },
+      {
+        "template": "En el futuro, tú ______ (ser) un gran profesional.",
+        "answer": "serás"
+      },
+      {
+        "template": "La próxima semana, el evento ______ (ser) en el auditorio.",
+        "answer": "será"
+      },
+      {
+        "template": "Nosotros ______ (ser) más cuidadosos la próxima vez.",
+        "answer": "seremos"
+      },
+      {
+        "template": "Vosotros ______ (ser) los responsables del proyecto.",
+        "answer": "seréis"
+      },
+      {
+        "template": "Ellos ______ (ser) los ganadores si se esfuerzan.",
+        "answer": "serán"
+      }
+    ],
+    "imperativo_afirmativo": [
+      {
+        "template": "(Tú) ¡______ (ser) bueno y pórtate bien!",
+        "answer": "sé"
+      },
+      {
+        "template": "(Usted) ______ (ser) amable con los clientes.",
+        "answer": "sea"
+      },
+      {
+        "template": "(Nosotros) ______ (ser) un ejemplo para los demás.",
+        "answer": "seamos"
+      },
+      {
+        "template": "(Vosotros) ¡______ (ser) valientes y no tengáis miedo!",
+        "answer": "sed"
+      },
+      {
+        "template": "(Ustedes) ______ (ser) bienvenidos a la reunión.",
+        "answer": "sean"
+      }
+    ],
+    "imperfecto": [
+      {
+        "template": "Cuando yo era niño, ______ (ser) muy travieso.",
+        "answer": "era"
+      },
+      {
+        "template": "Tú ______ (ser) un buen estudiante en la escuela primaria.",
+        "answer": "eras"
+      },
+      {
+        "template": "Él ______ (ser) el capitán del equipo.",
+        "answer": "era"
+      },
+      {
+        "template": "Nosotros ______ (ser) los únicos que hablaban español en la clase.",
+        "answer": "éramos"
+      },
+      {
+        "template": "Vosotros ______ (ser) muy unidos en aquel entonces.",
+        "answer": "erais"
+      },
+      {
+        "template": "Ellos ______ (ser) felices con poco.",
+        "answer": "eran"
+      }
+    ],
+    "pluscuamperfecto": [
+      {
+        "template": "Antes de la mudanza, yo ya ______ (ser) notificado del cambio.",
+        "answer": "había sido"
+      },
+      {
+        "template": "Tú ______ (ser) advertido varias veces antes del incidente.",
+        "answer": "habías sido"
+      },
+      {
+        "template": "Cuando llegamos, él ya ______ (ser) el director por cinco años.",
+        "answer": "había sido"
+      },
+      {
+        "template": "Nosotros ______ (ser) amigos desde la infancia hasta ese momento.",
+        "answer": "habíamos sido"
+      },
+      {
+        "template": "Vosotros ya ______ (ser) informados cuando os llamé.",
+        "answer": "habíais sido"
+      },
+      {
+        "template": "Ellos ______ (ser) muy unidos antes de la discusión.",
+        "answer": "habían sido"
+      }
+    ],
+    "presente": [
+      {
+        "template": "Yo ______ (ser) un estudiante.",
+        "answer": "soy"
+      },
+      {
+        "template": "Tú ______ (ser) muy inteligente.",
+        "answer": "eres"
+      },
+      {
+        "template": "Él ______ (ser) doctor.",
+        "answer": "es"
+      },
+      {
+        "template": "Nosotros ______ (ser) amigos.",
+        "answer": "somos"
+      },
+      {
+        "template": "Vosotros ______ (ser) de España.",
+        "answer": "sois"
+      },
+      {
+        "template": "Ellos ______ (ser) altos.",
+        "answer": "son"
+      }
+    ],
+    "preterito_indefinido": [
+      {
+        "template": "Ayer yo ______ (ser) el único en la oficina.",
+        "answer": "fui"
+      },
+      {
+        "template": "Anoche tú ______ (ser) el alma de la fiesta.",
+        "answer": "fuiste"
+      },
+      {
+        "template": "El mes pasado, él ______ (ser) promovido a gerente.",
+        "answer": "fue"
+      },
+      {
+        "template": "Nosotros ______ (ser) compañeros de clase en 2010.",
+        "answer": "fuimos"
+      },
+      {
+        "template": "Vosotros ______ (ser) los fundadores de la empresa.",
+        "answer": "fuisteis"
+      },
+      {
+        "template": "Ellos ______ (ser) muy amables con nosotros durante la visita.",
+        "answer": "fueron"
+      }
+    ],
+    "preterito_perfecto_compuesto": [
+      {
+        "template": "Hoy yo ______ (ser) muy productivo.",
+        "answer": "he sido"
+      },
+      {
+        "template": "Esta semana tú ______ (ser) de gran ayuda.",
+        "answer": "has sido"
+      },
+      {
+        "template": "Él siempre ______ (ser) un buen amigo.",
+        "answer": "ha sido"
+      },
+      {
+        "template": "Nosotros ______ (ser) consistentes con nuestro trabajo.",
+        "answer": "hemos sido"
+      },
+      {
+        "template": "Vosotros ______ (ser) los mejores en la competencia.",
+        "answer": "habéis sido"
+      },
+      {
+        "template": "Ellos ______ (ser) informados sobre la situación.",
+        "answer": "han sido"
+      }
+    ],
+    "subjuntivo_imperfecto_ra": [
+      {
+        "template": "Si yo ______ (ser) más alto, jugaría baloncesto.",
+        "answer": "fuera"
+      },
+      {
+        "template": "Si tú ______ (ser) más paciente, entenderías mejor.",
+        "answer": "fueras"
+      },
+      {
+        "template": "Si él ______ (ser) el jefe, cambiaría muchas cosas.",
+        "answer": "fuera"
+      },
+      {
+        "template": "Si nosotros ______ (ser) más ricos, viajaríamos por el mundo.",
+        "answer": "fuéramos"
+      },
+      {
+        "template": "Si vosotros ______ (ser) más organizados, terminaríais antes.",
+        "answer": "fuerais"
+      },
+      {
+        "template": "Si ellos ______ (ser) menos ruidosos, podríamos concentrarnos.",
+        "answer": "fueran"
+      }
+    ],
+    "subjuntivo_presente": [
+      {
+        "template": "Espero que yo ______ (ser) una buena influencia.",
+        "answer": "sea"
+      },
+      {
+        "template": "Es importante que tú ______ (ser) honesto.",
+        "answer": "seas"
+      },
+      {
+        "template": "Dudo que él ______ (ser) el culpable.",
+        "answer": "sea"
+      },
+      {
+        "template": "Es necesario que nosotros ______ (ser) puntuales.",
+        "answer": "seamos"
+      },
+      {
+        "template": "Es posible que vosotros ______ (ser) los elegidos.",
+        "answer": "seáis"
+      },
+      {
+        "template": "Es probable que ellos ______ (ser) promovidos.",
+        "answer": "sean"
+      }
+    ]
+  },
+  "tener": {
+    "condicional": [
+      {
+        "template": "Si yo fuera rico, ______ (tener) un yate.",
+        "answer": "tendría"
+      },
+      {
+        "template": "Tú ______ (tener) más éxito si trabajaras más duro.",
+        "answer": "tendrías"
+      },
+      {
+        "template": "Él ______ (tener) mejores notas si estudiara más.",
+        "answer": "tendría"
+      },
+      {
+        "template": "Nosotros ______ (tener) una casa en la playa si ahorráramos.",
+        "answer": "tendríamos"
+      },
+      {
+        "template": "Vosotros ______ (tener) menos problemas si fuerais más cuidadosos.",
+        "answer": "tendríais"
+      },
+      {
+        "template": "Ellos ______ (tener) más amigos si fueran más sociables.",
+        "answer": "tendrían"
+      }
+    ],
+    "futuro": [
+      {
+        "template": "Mañana yo ______ (tener) más tiempo libre.",
+        "answer": "tendré"
+      },
+      {
+        "template": "El próximo año tú ______ (tener) nuevas responsabilidades.",
+        "answer": "tendrás"
+      },
+      {
+        "template": "Él ______ (tener) que tomar una decisión importante.",
+        "answer": "tendrá"
+      },
+      {
+        "template": "Nosotros ______ (tener) una reunión con el director la próxima semana.",
+        "answer": "tendremos"
+      },
+      {
+        "template": "Vosotros ______ (tener) la oportunidad de demostrar vuestro talento.",
+        "answer": "tendréis"
+      },
+      {
+        "template": "Ellos ______ (tener) que adaptarse a los cambios.",
+        "answer": "tendrán"
+      }
+    ],
+    "imperativo_afirmativo": [
+      {
+        "template": "(Tú) ¡______ (tener) cuidado con el perro!",
+        "answer": "ten"
+      },
+      {
+        "template": "(Usted) ______ (tener) paciencia, por favor.",
+        "answer": "tenga"
+      },
+      {
+        "template": "(Nosotros) ______ (tener) fe en que todo saldrá bien.",
+        "answer": "tengamos"
+      },
+      {
+        "template": "(Vosotros) ¡______ (tener) un buen viaje!",
+        "answer": "tened"
+      },
+      {
+        "template": "(Ustedes) ______ (tener) en cuenta las recomendaciones.",
+        "answer": "tengan"
+      }
+    ],
+    "imperfecto": [
+      {
+        "template": "Cuando era niño, yo ______ (tener) un perro.",
+        "answer": "tenía"
+      },
+      {
+        "template": "Antes, tú ______ (tener) el pelo más largo.",
+        "answer": "tenías"
+      },
+      {
+        "template": "Él ______ (tener) una bicicleta roja cuando era pequeño.",
+        "answer": "tenía"
+      },
+      {
+        "template": "Nosotros ______ (tener) muchos amigos en la vieja escuela.",
+        "answer": "teníamos"
+      },
+      {
+        "template": "Vosotros siempre ______ (tener) juguetes interesantes.",
+        "answer": "teníais"
+      },
+      {
+        "template": "Ellos ______ (tener) una casa cerca del mar.",
+        "answer": "tenían"
+      }
+    ],
+    "pluscuamperfecto": [
+      {
+        "template": "Antes de ganar la lotería, yo nunca ______ (tener) tanto dinero.",
+        "answer": "había tenido"
+      },
+      {
+        "template": "Tú ya ______ (tener) experiencia en ese campo antes de aplicar.",
+        "answer": "habías tenido"
+      },
+      {
+        "template": "Él ______ (tener) varios coches antes de comprar el actual.",
+        "answer": "había tenido"
+      },
+      {
+        "template": "Nosotros ______ (tener) problemas similares en el pasado.",
+        "answer": "habíamos tenido"
+      },
+      {
+        "template": "Vosotros ______ (tener) esa discusión muchas veces antes.",
+        "answer": "habíais tenido"
+      },
+      {
+        "template": "Ellos ______ (tener) la oportunidad de conocerlo antes del evento.",
+        "answer": "habían tenido"
+      }
+    ],
+    "presente": [
+      {
+        "template": "Yo ______ (tener) un coche nuevo.",
+        "answer": "tengo"
+      },
+      {
+        "template": "Tú ______ (tener) mucha suerte.",
+        "answer": "tienes"
+      },
+      {
+        "template": "Ella ______ (tener) dos hermanos.",
+        "answer": "tiene"
+      },
+      {
+        "template": "Nosotros ______ (tener) una casa grande.",
+        "answer": "tenemos"
+      },
+      {
+        "template": "Vosotros ______ (tener) hambre.",
+        "answer": "tenéis"
+      },
+      {
+        "template": "Ustedes ______ (tener) que estudiar más.",
+        "answer": "tienen"
+      }
+    ],
+    "preterito_indefinido": [
+      {
+        "template": "Ayer yo ______ (tener) un examen muy difícil.",
+        "answer": "tuve"
+      },
+      {
+        "template": "Anoche tú ______ (tener) una pesadilla.",
+        "answer": "tuviste"
+      },
+      {
+        "template": "El año pasado él ______ (tener) un accidente de coche.",
+        "answer": "tuvo"
+      },
+      {
+        "template": "Nosotros ______ (tener) una reunión importante esta mañana.",
+        "answer": "tuvimos"
+      },
+      {
+        "template": "Vosotros ______ (tener) que esperar mucho tiempo en la fila.",
+        "answer": "tuvisteis"
+      },
+      {
+        "template": "Ellos ______ (tener) una gran fiesta para su aniversario.",
+        "answer": "tuvieron"
+      }
+    ],
+    "preterito_perfecto_compuesto": [
+      {
+        "template": "Hoy yo ______ (tener) un día muy ocupado.",
+        "answer": "he tenido"
+      },
+      {
+        "template": "Esta semana tú ______ (tener) muchos exámenes.",
+        "answer": "has tenido"
+      },
+      {
+        "template": "Él siempre ______ (tener) el apoyo de su familia.",
+        "answer": "ha tenido"
+      },
+      {
+        "template": "Nosotros ______ (tener) algunos problemas con el coche.",
+        "answer": "hemos tenido"
+      },
+      {
+        "template": "Vosotros ______ (tener) la oportunidad de viajar mucho.",
+        "answer": "habéis tenido"
+      },
+      {
+        "template": "Ellos ______ (tener) que trabajar hasta tarde hoy.",
+        "answer": "han tenido"
+      }
+    ],
+    "subjuntivo_imperfecto_ra": [
+      {
+        "template": "Si yo ______ (tener) más dinero, viajaría más.",
+        "answer": "tuviera"
+      },
+      {
+        "template": "Si tú ______ (tener) más cuidado, no te lastimarías.",
+        "answer": "tuvieras"
+      },
+      {
+        "template": "Si él ______ (tener) más tiempo, nos ayudaría.",
+        "answer": "tuviera"
+      },
+      {
+        "template": "Si nosotros ______ (tener) un coche, iríamos a la playa.",
+        "answer": "tuviéramos"
+      },
+      {
+        "template": "Si vosotros ______ (tener) la oportunidad, ¿la aprovecharíais?",
+        "answer": "tuvierais"
+      },
+      {
+        "template": "Si ellos ______ (tener) más información, tomarían una decisión.",
+        "answer": "tuvieran"
+      }
+    ],
+    "subjuntivo_presente": [
+      {
+        "template": "Espero que yo ______ (tener) buenas noticias pronto.",
+        "answer": "tenga"
+      },
+      {
+        "template": "Es importante que tú ______ (tener) paciencia.",
+        "answer": "tengas"
+      },
+      {
+        "template": "Es posible que ella ______ (tener) razón.",
+        "answer": "tenga"
+      },
+      {
+        "template": "Es necesario que nosotros ______ (tener) un plan.",
+        "answer": "tengamos"
+      },
+      {
+        "template": "Dudo que vosotros ______ (tener) tiempo suficiente.",
+        "answer": "tengáis"
+      },
+      {
+        "template": "Es probable que ellos ______ (tener) algunas preguntas.",
+        "answer": "tengan"
+      }
+    ]
+  },
+  "ver": {
+    "condicional": [
+      {
+        "template": "Si tuviera gafas, yo ______ (ver) mejor la pizarra.",
+        "answer": "vería"
+      },
+      {
+        "template": "¿Tú ______ (ver) esa película de miedo solo en casa?",
+        "answer": "verías"
+      },
+      {
+        "template": "Él ______ (ver) el partido si no tuviera que trabajar.",
+        "answer": "vería"
+      },
+      {
+        "template": "Nosotros ______ (ver) el amanecer si nos levantáramos temprano.",
+        "answer": "veríamos"
+      },
+      {
+        "template": "Vosotros ______ (ver) las estrellas si no estuviera nublado.",
+        "answer": "veríais"
+      },
+      {
+        "template": "Ellos ______ (ver) la obra de teatro si consiguieran entradas.",
+        "answer": "verían"
+      }
+    ],
+    "futuro": [
+      {
+        "template": "Mañana yo ______ (ver) a mis abuelos.",
+        "answer": "veré"
+      },
+      {
+        "template": "¿Cuándo ______ (ver) tú los resultados del examen?",
+        "answer": "verás"
+      },
+      {
+        "template": "Él ______ (ver) el partido en casa de un amigo.",
+        "answer": "verá"
+      },
+      {
+        "template": "Nosotros ______ (ver) la nueva exposición en el museo.",
+        "answer": "veremos"
+      },
+      {
+        "template": "Vosotros ______ (ver) si podéis venir a la fiesta.",
+        "answer": "veréis"
+      },
+      {
+        "template": "Ellos ______ (ver) la película en el cine este fin de semana.",
+        "answer": "verán"
+      }
+    ],
+    "imperativo_afirmativo": [
+      {
+        "template": "(Tú) ¡______ (ver) qué bonito paisaje!",
+        "answer": "ve"
+      },
+      {
+        "template": "(Usted) ______ (ver) la demostración con atención.",
+        "answer": "vea"
+      },
+      {
+        "template": "(Nosotros) ______ (ver) si podemos ayudar en algo.",
+        "answer": "veamos"
+      },
+      {
+        "template": "(Vosotros) ¡______ (ver) la película, es muy buena!",
+        "answer": "ved"
+      },
+      {
+        "template": "(Ustedes) ______ (ver) las instrucciones antes de empezar.",
+        "answer": "vean"
+      }
+    ],
+    "imperfecto": [
+      {
+        "template": "Cuando era niño, yo ______ (ver) dibujos animados todas las tardes.",
+        "answer": "veía"
+      },
+      {
+        "template": "Tú ______ (ver) a tus abuelos todos los fines de semana.",
+        "answer": "veías"
+      },
+      {
+        "template": "Él ______ (ver) el mar desde la ventana de su habitación.",
+        "answer": "veía"
+      },
+      {
+        "template": "Nosotros ______ (ver) las estrellas fugaces en las noches de verano.",
+        "answer": "veíamos"
+      },
+      {
+        "template": "Vosotros ______ (ver) los partidos de vuestro equipo favorito juntos.",
+        "answer": "veíais"
+      },
+      {
+        "template": "Ellos ______ (ver) el desfile desde el balcón de su casa.",
+        "answer": "veían"
+      }
+    ],
+    "pluscuamperfecto": [
+      {
+        "template": "Yo ya ______ (ver) la película antes de que me la recomendaras.",
+        "answer": "había visto"
+      },
+      {
+        "template": "Tú ______ (ver) el accidente antes de que llegara la policía.",
+        "answer": "habías visto"
+      },
+      {
+        "template": "Él ______ (ver) esa obra de teatro varias veces.",
+        "answer": "había visto"
+      },
+      {
+        "template": "Nosotros ______ (ver) el arcoíris después de la tormenta.",
+        "answer": "habíamos visto"
+      },
+      {
+        "template": "Vosotros ______ (ver) el anuncio en la televisión antes de comprar el producto.",
+        "answer": "habíais visto"
+      },
+      {
+        "template": "Ellos ______ (ver) al ladrón escapar antes de que sonara la alarma.",
+        "answer": "habían visto"
+      }
+    ],
+    "presente": [
+      {
+        "template": "Yo ______ (ver) las noticias todas las mañanas.",
+        "answer": "veo"
+      },
+      {
+        "template": "Tú ______ (ver) películas de terror los fines de semana.",
+        "answer": "ves"
+      },
+      {
+        "template": "Ella ______ (ver) a sus amigos después de clase.",
+        "answer": "ve"
+      },
+      {
+        "template": "Nosotros ______ (ver) un partido de fútbol en la televisión.",
+        "answer": "vemos"
+      },
+      {
+        "template": "Vosotros ______ (ver) las estrellas desde el balcón.",
+        "answer": "veis"
+      },
+      {
+        "template": "Ustedes ______ (ver) el amanecer desde la montaña.",
+        "answer": "ven"
+      }
+    ],
+    "preterito_indefinido": [
+      {
+        "template": "Ayer yo ______ (ver) una estrella fugaz en el cielo.",
+        "answer": "vi"
+      },
+      {
+        "template": "¿Qué película ______ (ver) tú anoche en el cine?",
+        "answer": "viste"
+      },
+      {
+        "template": "Él ______ (ver) el accidente desde su ventana.",
+        "answer": "vio"
+      },
+      {
+        "template": "Nosotros ______ (ver) un documental muy interesante sobre la naturaleza.",
+        "answer": "vimos"
+      },
+      {
+        "template": "Vosotros ______ (ver) el partido de baloncesto en directo.",
+        "answer": "visteis"
+      },
+      {
+        "template": "Ellos ______ (ver) a sus abuelos durante las vacaciones.",
+        "answer": "vieron"
+      }
+    ],
+    "preterito_perfecto_compuesto": [
+      {
+        "template": "Yo ______ (ver) esa película tres veces.",
+        "answer": "he visto"
+      },
+      {
+        "template": "¿Tú ______ (ver) el último episodio de la serie?",
+        "answer": "has visto"
+      },
+      {
+        "template": "Ella ______ (ver) un fantasma en la casa abandonada.",
+        "answer": "ha visto"
+      },
+      {
+        "template": "Nosotros ______ (ver) muchos cambios en la ciudad últimamente.",
+        "answer": "hemos visto"
+      },
+      {
+        "template": "Vosotros ______ (ver) el cometa pasar esta noche, ¿verdad?",
+        "answer": "habéis visto"
+      },
+      {
+        "template": "Ellos ______ (ver) el partido en el estadio.",
+        "answer": "han visto"
+      }
+    ],
+    "subjuntivo_imperfecto_ra": [
+      {
+        "template": "Si yo ______ (ver) un fantasma, gritaría.",
+        "answer": "viera"
+      },
+      {
+        "template": "Si tú ______ (ver) a Juan, ¿le dirías que lo estoy buscando?",
+        "answer": "vieras"
+      },
+      {
+        "template": "Si él ______ (ver) la oportunidad, la aprovecharía.",
+        "answer": "viera"
+      },
+      {
+        "template": "Si nosotros ______ (ver) el peligro, nos protegeríamos.",
+        "answer": "viéramos"
+      },
+      {
+        "template": "Si vosotros ______ (ver) un accidente, llamaríais a emergencias.",
+        "answer": "vierais"
+      },
+      {
+        "template": "Si ellos ______ (ver) el problema, intentarían solucionarlo.",
+        "answer": "vieran"
+      }
+    ],
+    "subjuntivo_presente": [
+      {
+        "template": "Espero que yo ______ (ver) a mis amigos en la fiesta.",
+        "answer": "vea"
+      },
+      {
+        "template": "Es importante que tú ______ (ver) al médico por ese dolor.",
+        "answer": "veas"
+      },
+      {
+        "template": "Es posible que ella ______ (ver) la película esta noche.",
+        "answer": "vea"
+      },
+      {
+        "template": "Es necesario que nosotros ______ (ver) todas las opciones antes de decidir.",
+        "answer": "veamos"
+      },
+      {
+        "template": "Dudo que vosotros ______ (ver) el final de la serie hoy.",
+        "answer": "veáis"
+      },
+      {
+        "template": "Es probable que ellos ______ (ver) el partido en el bar.",
+        "answer": "vean"
+      }
+    ]
   }
 };
 
 export const availableVerbs: string[] = [
   "comer",
-  "hablar"
+  "dar",
+  "decir",
+  "estar",
+  "hablar",
+  "hacer",
+  "ir",
+  "poder",
+  "saber",
+  "ser",
+  "tener",
+  "ver"
 ];
 
 export const availableTenses: string[] = [
+  "condicional",
   "futuro",
+  "imperativo_afirmativo",
+  "imperfecto",
+  "pluscuamperfecto",
   "presente",
-  "pretérito"
+  "preterito_indefinido",
+  "preterito_perfecto_compuesto",
+  "pretérito",
+  "subjuntivo_imperfecto_ra",
+  "subjuntivo_presente"
 ];
 
 // Groupings based on actual available tenses
 export const tenseGroups: { [key: string]: string[] } = {
   "present": [
-    "presente"
+    "presente",
+    "subjuntivo_presente"
   ],
   "past": [
-    "pretérito"
+    "imperfecto",
+    "preterito_indefinido",
+    "preterito_perfecto_compuesto",
+    "pluscuamperfecto",
+    "subjuntivo_imperfecto_ra"
   ],
   "future": [
     "futuro"
+  ],
+  "conditional": [
+    "condicional"
+  ],
+  "imperative": [
+    "imperativo_afirmativo"
   ]
 };
 


### PR DESCRIPTION
This commit introduces data for 10 new Spanish verbs: ser, estar, tener, hacer, poder, decir, ir, ver, dar, saber.

For each of these verbs, example sentences have been added for the following 10 tenses:
- Presente de Indicativo
- Pretérito Perfecto Compuesto de Indicativo
- Pretérito Imperfecto de Indicativo
- Pretérito Pluscuamperfecto de Indicativo
- Pretérito Indefinido
- Futuro Simple de Indicativo
- Condicional Simple de Indicativo
- Presente de Subjuntivo
- Pretérito Imperfecto de Subjuntivo (-ra form)
- Imperativo Afirmativo

The `scripts/build-data.mjs` was updated to include these new tense groupings, and `src/data.ts` has been regenerated to include all new verb data. The original 'comer' and 'hablar' verbs remain.

You will perform application testing after I complete this.